### PR TITLE
Create bgInput field on wizard events to surface BGs entered into wizard

### DIFF
--- a/data-model/v1/basal.md
+++ b/data-model/v1/basal.md
@@ -22,8 +22,8 @@ This represents an injection of a long-acting insulin.
   "deliveryType": "injected",
   "value": total_number_of_units_injected,
   "duration": number_of_milliseconds_this_injection_is_expected_to_last,
-  "time": see_common_fields,
   "insulin": name_of_insulin_used,
+  "time": see_common_fields,
   "deviceId": see_common_fields,
   "source": see_common_fields
 }
@@ -36,6 +36,8 @@ The fields generally follow the same semantics as other basal events, except
 2. `value` it is worth it to note that the value is the total number of units injected, rather than the amount per hour as is the case with the other basal types
 
 3. `insulin` is a field that exists to provide an indication of what type of insulin was injected.  For example, levemir, lantus, etc.  There is a registry of possible values for this field, submitting a value that is not in this registry will cause the event to be rejected.  It is our hope that this can be used to generate an appoximation of the rate at which the insulin should affect the PwD.
+
+4. `previous` is not specified.  This is because an injection is always additive to whatever other basal activity is going on.
 
 ### Scheduled
 

--- a/data-model/v1/smbg.md
+++ b/data-model/v1/smbg.md
@@ -1,6 +1,6 @@
 # SMBG
 
-SMBG represents blood glucose from a finger prick or other "self-monitoring" mehod.  These events are point-in-time and look like
+SMBG represents blood glucose from a finger prick or other "self-monitoring" method.  These events are point-in-time and look like
 
 
 ``` json

--- a/data-model/v1/wizard.md
+++ b/data-model/v1/wizard.md
@@ -1,13 +1,14 @@
 # Wizard
 
-Wizard events represent interactions with a bolus wizard on a pump.  The event is intended to contain the values that were input into the Wizard as well as the values that the wizard might have recommended for a bolus.
+Wizard events represent interactions with a "bolus wizard" or "bolus calculator" on a pump.  The event is intended to contain the values that were input into the wizard, as well as any recommendations that the wizard might have made.
 
 Wizard events are point-in-time and look like
 
 ``` json
 {
   "type": "wizard",
-  "recommended": number_of_units_recommended
+  "recommended": number_of_units_recommended,
+  "bgInput": bg_as_input_into_wizard,
   "payload": see_below,
   "time": see_common_fields,
   "deviceId": see_common_fields,
@@ -17,6 +18,7 @@ Wizard events are point-in-time and look like
 ```
 
 * `recommended` is the number of units of insulin that the wizard recommended that the PwD inject.
+* `bgInput` the blood glucose value input into the wizard.
 * `payload` is an object of arbitrary fields that will be stored alongside the wizard event.  An example of things that might be stored is:
 
     ``` json


### PR DESCRIPTION
@jebeck @brandonarbiter @skrugman @HowardLook 

This is a proposal for how to resolve the request from Aaron and Brandon for being able to semantically differentiate a finger prick from a value entered into the pump.

The idea is that the wizard event gets a field for the level of blood glucose that was entered into it.  We then need to adjust the front end visualization to be able to visualize wizard-entered blood glucose in some way that differentiates it from `smbg`.

Thoughts? 
