### PR TITLE
Adjustments to the semantics of status events

### DIFF
--- a/_docs/data-model/v1/annotations.md
+++ b/_docs/data-model/v1/annotations.md
@@ -32,7 +32,7 @@ We document our known annotations below, but we do not limit the set of annotati
 * `basal/mismatched-series` happens when the API receives an basal event with a `previous` field that does not line up with the basal event immediately before it in the stream of basal events.
 * `status/incomplete-tuple` happens when a `deviceMeta` `status` event is sent in and never completed.  See the [Device Metadata](device-meta) page for more details.
 * `status/unknown-previous` happens when a `deviceMeta` `status` event is sent in with a `previous` field that doesn't reference an object in the Tidepool platform.  Accompanied by an `id` field:
-    * `id` the expected id of the previous event as specified in the `previous` field on the event submitted to the Tidepool platform
+    * `id` the expected id of the previous event as specified in the `previous` field on the event submitted to the Tidepool platform.  This might be null or just not exist if there wasn't a `previous` field provided on the submitted event.
 
 ### Carelink
 

--- a/_docs/data-model/v1/device-meta.md
+++ b/_docs/data-model/v1/device-meta.md
@@ -49,7 +49,7 @@ Status events come in tuples delivered over time.  The first event in the tuple 
 
 Also, the final status event in an incomplete tuple will be annotated as such.  When the tuple is complete, the server will remove the annotation.  Said another way, if everything is in order, "resumed" events will not be stored, but instead it will be used to adjust the `duration` of the status event that came before them.
 
-In the unlikely event that the event specified by the `previous` field does not exist in the Tidepool platform, the submitted event will be stored, but it will be annotated with "status/unknown-previous" to indicate the condition.
+In the unlikely event that the event specified by the `previous` field does not exist in the Tidepool platform, the submitted event will be stored, but it will be annotated with "status/unknown-previous" to indicate the condition.  If there is no `previous` field specified on a "resumed" event, that will also result in this annotation being added.
 
 ### Storage/Output Format
 


### PR DESCRIPTION
@kentquirk @jebeck 

These are some changes to the data model to (hopefully) make it a bit easier to work with the suspensions.  Please read it over and let me know if things need more clarification.
