### PR TITLE
Create raspberry-pi-getting-started

### DIFF
--- a/_docs/raspberry-pi-getting-started
+++ b/_docs/raspberry-pi-getting-started
@@ -1,0 +1,17 @@
+My forays into installing tidepool according to instructions at http://developer.tidepool.io/starting-up-services/ -- intended as a proof-of-concept.  No guarantees of speed, reliability, or usability (though everything seems to indicate that it is usable speed when rendered in chrome):
+
+-Install linux prerequisites that come as packages: git, bzr used apt-cache search <keyword> for exact name
+-Installed node.js using instructions at http://joshondesign.com/2013/10/23/noderpi (actually ended up using package method of http://weworkweplay.com/play/raspberry-pi-nodejs/ )
+-installed  node-gyp, bower, grunt-cli, gulp, mocha using sudo npm install -g <package>
+-Increased swap file to 1GB according to these instructions http://lokir.wordpress.com/2012/10/13/raspberry-pi-debian-how-to-change-swap-size/ -- not sure this was needed
+-Installed go on raspberry pi from http://dave.cheney.net/unofficial-arm-tarballs  
+-Github SSH - Installed an ssh key from my raspberry pi for github using these instructions https://help.github.com/articles/generating-ssh-keys 
+-Mongo DB was installed by cloning ArduPi from https://github.com/brice-morin/ArduPi -- this has precompiled mongodb binaries in a directory with instructions (avoided having to compile hopefully) and followed these instructions https://github.com/brice-morin/ArduPi/tree/master/mongodb-rpi/linux-test
+-made directory /data/db and made sure to start mongod pointed to this directory since it is what tidepool expects
+tested with web tests from point 6 -- mongodb version is 2.1.1 -- does it really matter?  NO!
+-consulted tidepool support to find out that blip and jellyfish required git checkouts of v0.1.2.7 and v0.2.4 respectivly in their directories, followed by a npm install for each (version current as of September 17, 2014, may not apply when you read this)
+-was finally able to execute . tools/runservers and waited for 7-10 minutes for framework to install and run
+-tested blip and jellyfish by going to http://localhost:3000 and http://localhost:3004 respectively -- success
+-usable speed when tested with google chrome -- tested by uploading a Dexcom tab-delimited file, my pump (Omnipod) is not yet supported.
+
+Good luck with this, please read carefully as this is not supported or necessarily endorsed, and meant as a proof-of-concept.


### PR DESCRIPTION
How to install tidepool framework onto a raspberry pi model b based on instructions at http://developer.tidepool.io/starting-up-services/ -- intended as a proof-of-concept -- no guarantees of speed and/or usability (even though once app is started browser behavior is reasonable)
