### PR TITLE
add rate to basals of deliveryType 'suspend'

### DIFF
--- a/_docs/data-model/v1/basal.md
+++ b/_docs/data-model/v1/basal.md
@@ -290,6 +290,7 @@ Suspended basals are much the same as scheduled and temp basals:
     {
       "type": "basal",
       "deliveryType": "suspend",
+      "rate": 0.0,
       "duration": number_of_milliseconds_the_suspend_will_be_in_effect_if_known,
       "time": see_common_fields,
       "deviceId": see_common_fields,
@@ -299,7 +300,7 @@ Suspended basals are much the same as scheduled and temp basals:
     }
 ~~~
 
-These fields are a subset of those from a scheduled basal.  The `duration` is optional, but *should* be provided if there is some mechanism that will turn the pump back on automatically after some elapsed period of time.
+These fields are a subset of those from a scheduled basal.  The `rate` is always 0.0.  The `duration` is optional, but *should* be provided if there is some mechanism that will turn the pump back on automatically after some elapsed period of time.
 
 The `suppressed` field represents any basals that this suspend event is suppressing.  The pump should make an effort to try to emit events whenever there is a change in the actual basal that would have been delivered if the suspension weren't in operation.  This may not always be possible, however, and in cases where it is not possible, it is acceptable to send a suspended event without a `suppressed` field.
 


### PR DESCRIPTION
Yesterday I missed the fact that @cheddar had omitted the `rate` from basals with a `deliveryType` of `suspend`. I believe that this field should be included, even though it is always 0.0 for this `deliveryType`. The fact that the visualization code needs a rate to calculate the height of the path is irrelevant when discussing the storage data model, so I won't make *that* argument here. The argument I will make is that events of type `basal` represent the delivery of insulin in some form (for `deliveryType: injected` this is a `value` field instead of `rate`), and it feels sloppy to me to force users of the data to infer the actual amount of insulin delivery from the `deliveryType` in some cases.

Whoever wants to weigh in on this, please do: @kentquirk @jh-bate @ianjorgensen @brandonarbiter @HowardLook 