### PR TITLE
add net to wizard recommendations

### DIFF
--- a/_docs/data-model/v1/wizard.md
+++ b/_docs/data-model/v1/wizard.md
@@ -14,7 +14,8 @@ Wizard events are point-in-time and look like
   "type": "wizard",
   "recommended": {
     "carb": number_of_units_to_cover_carbs,
-    "correction": number_of_units_to_cover_correction
+    "correction": number_of_units_to_cover_correction,
+    "net": total_recommendation_after_insulin_on_board_accounting_if_any
   },
   "bgInput": bg_as_input_into_wizard,
   "carbInput": carbohydrates_as_input_into_wizard_in_mg,
@@ -32,6 +33,7 @@ Wizard events are point-in-time and look like
 
 * `recommended.carb` is the number of units of insulin that the wizard recommended to cover carbohydrate intake.
 * `recommended.correction` is the number of units of insulin that the wizard recommended to attempt to bring the PwD down to their target BG.
+* `recommended.net` is the net number of units of insulin that the wizard recommended, taking into account `recommended.carb`, `recommended.correction`, and `insulinOnBoard`. We store the result of this calculation because different devices do this calculation in different ways.
 * `bgInput` is the blood glucose value input into the wizard.  This is converted to mmol/l based on a `units` field.
 * `carbInput` is the carbohydrate value (mg) input into the wizard, note that this is not necessarily an indication of carbohydrates that were actually consumed.  It is, instead, an indication of carbohydrates that the PwD entered into their pump.
 * `insulinOnBoard` is the units of insulin currently in suspension inside of the PwD.  Metaphorically speaking, this can be thought of as how many little yellow school buses with Mrs. Frizzle and kids are floating around learning about the PwD's anatomy.


### PR DESCRIPTION
This is the data model change that I mentioned for fixing suggested in bolus tooltips @brandonarbiter 

As discussed with @kentquirk and @jh-bate also.

I'm not particularly attached to the word `net`, but I do prefer it over `total`, which I think could be misleading, given that the value will often be less than the sum of the `recommended.carb` and `recommended.correction`.

