### PR TITLE
draft of additional  codes for  deviceMeta events

### DIFF
--- a/_docs/data-model/v1/device-meta.md
+++ b/_docs/data-model/v1/device-meta.md
@@ -43,7 +43,7 @@ A status event is used to represent the status of a pump.  Specifically, this is
     * "alarm" - the pump automatically suspended due to an alarm
 * For resumed status
     * "manual" - the user manually resumed the pump
-    * "automatic" - the pump resume on its own
+    * "automatic" - the pump resumed on its own
     * "automatic/user-accepted" - the pump resumed on its own after low-glucose suspend (LGS); the user cleared at least one LGS alarm, indicating tacit acceptance of the suspend
     * "automatic/user-ignored" - the pump resumed on its own after low-glucose suspend (LGS); the user did not respond to any of the LGS alarms
 

--- a/_docs/data-model/v1/device-meta.md
+++ b/_docs/data-model/v1/device-meta.md
@@ -5,7 +5,7 @@ published: true
 ---
 # DeviceMeta
 
-DeviceMeta events are a catch-all for metadata about whatever device is currently being used.  We expect the domain of deviceMeta events to expand regularly as we want to track more and more things about the device-proper.
+DeviceMeta events are a catch-all for metadata about whatever device is currently being used.  We expect the domain of deviceMeta events to expand regularly as we want to track more and more things about the device proper.
 
 The "type" of a deviceMeta event is defined by the `subType` field.
 
@@ -43,7 +43,9 @@ A status event is used to represent the status of a pump.  Specifically, this is
     * "alarm" - the pump automatically suspended due to an alarm
 * For resumed status
     * "manual" - the user manually resumed the pump
-    * "automatic" - the pump resumed on its own
+    * "automatic" - the pump resume on its own
+    * "automatic/user-accepted" - the pump resumed on its own after low-glucose suspend (LGS); the user cleared at least one LGS alarm, indicating tacit acceptance of the suspend
+    * "automatic/user-ignored" - the pump resumed on its own after low-glucose suspend (LGS); the user did not respond to any of the LGS alarms
 
 Status events come in tuples delivered over time.  The first event in the tuple must be a non "resumed" status, subsequent statuses can be any other status change until a "resumed" status is received.  The "resumed" event closes the tuple.  As each event in the tuple is received the system will update the duration of the previous event in the tuple according to the differences in the timestamps.
 

--- a/_docs/data-model/v1/device-meta.md
+++ b/_docs/data-model/v1/device-meta.md
@@ -24,7 +24,7 @@ A status event is used to represent the status of a pump.  Specifically, this is
   "type": "deviceMeta",
   "subType": "status",
   "status": suspended_or_resumed,
-  "reason": indication_of_why
+  "reason": indication_of_why,
   "time": see_common_fields,
   "duration": max_duration_of_status_if_known,
   "deviceId": see_common_fields,
@@ -55,6 +55,8 @@ In the unlikely event that the event specified by the `previous` field does not 
 
 ### Storage/Output Format
 
+The storage and output format for status events differs from what was initially ingested only with respect to the `reason` field for `status`-type events. (Also, the `previous` field will not actually be stored. Instead, it is used simply as a verfication mechanism.) The storage and output format combines the `reason` codes for each of the events making up a `status` tuple. In all cases, the `reason` field is an object with keys that corresponded to the `status` (i.e., `suspended` or `resumed`) and values chosen from the sets of appropriate reason codes for each `status`.
+
 The storage and output format for status events is essentially a mirror except the `previous` field will not actually be stored.  Instead, it is used simply as a verification mechanism.
 
 #### Example: Event submitted with previous that exists
@@ -66,7 +68,7 @@ If you were to first emit the event
   "type": "deviceMeta",
   "subType": "status",
   "status": "suspended",
-  "reason": "manual",
+  "reason": {"suspended": "manual"},
   "time": "2014-01-01T01:00:00.000Z",
   "deviceId": "123",
   "source": "example"
@@ -81,7 +83,7 @@ At this point, the tidepool platform will store and allow you to retrieve
     "type": "deviceMeta",
     "subType": "status",
     "status": "suspended",
-    "reason": "manual",
+    "reason": {"suspended": "manual"},
     "time": "2014-01-01T01:00:00.000Z",
     "deviceId": "123",
     "source": "example"
@@ -97,7 +99,7 @@ If you then emit
   "type": "deviceMeta",
   "subType": "status",
   "status": "resumed",
-  "reason": "manual",
+  "reason": {"resumed": "manual"},
   "time": "2014-01-01T01:30:00.000Z",
   "deviceId": "123",
   "source": "example",
@@ -105,7 +107,7 @@ If you then emit
     "type": "deviceMeta",
     "subType": "status",
     "status": "suspended",
-    "reason": "manual",
+    "reason": {"suspended": "manual"},
     "time": "2014-01-01T00:00:00.000Z",
     "deviceId": "123",
     "source": "example"
@@ -121,7 +123,7 @@ The tidepool platform will store and allow you to retrieve
     "type": "deviceMeta",
     "subType": "status",
     "status": "suspended",
-    "reason": "manual",
+    "reason": {"suspended": "manual", "resumed": "manual"},
     "time": "2014-01-01T01:00:00.000Z",
     "duration": 1800000,
     "deviceId": "123",
@@ -139,7 +141,7 @@ If you were to first emit the event
   "type": "deviceMeta",
   "subType": "status",
   "status": "suspended",
-  "reason": "manual",
+  "reason": {"resumed": "manual"},
   "time": "2014-01-01T00:00:00.000Z",
   "deviceId": "123",
   "source": "example"
@@ -153,7 +155,7 @@ And then emit
   "type": "deviceMeta",
   "subType": "status",
   "status": "resumed",
-  "reason": "manual",
+  "reason": {"resumed": "manual"},
   "time": "2014-01-01T02:00:00.000Z",
   "deviceId": "123",
   "source": "example",
@@ -161,7 +163,7 @@ And then emit
     "type": "deviceMeta",
     "subType": "status",
     "status": "suspended",
-    "reason": "manual",
+    "reason": {"suspended": "manual"},
     "time": "2014-01-01T01:00:00.000Z",
     "deviceId": "123",
     "source": "example"
@@ -177,7 +179,7 @@ The tidepool platform will store and allow you to retrieve
     "type": "deviceMeta",
     "subType": "status",
     "status": "suspended",
-    "reason": "manual",
+    "reason": {"suspended": "manual"},
     "time": "2014-01-00T00:00:00.000Z",
     "deviceId": "123",
     "source": "example",
@@ -187,7 +189,7 @@ The tidepool platform will store and allow you to retrieve
     "type": "deviceMeta",
     "subType": "status",
     "status": "resumed",
-    "reason": "manual",
+    "reason": {"resumed": "manual"},
     "time": "2014-01-01T02:00:00.000Z",
     "deviceId": "123",
     "source": "example",
@@ -213,4 +215,4 @@ A calibration event represents a calibration of a CGM.  It looks like
 
 ## Storage/Output Format
 
-The storage and output format for this datum is exactly what was initially ingested.  There are no modifications performed
+The storage and output format for this datum is exactly what was initially ingested.  There are no modifications performed.


### PR DESCRIPTION
Proposed addition to the data model. Let's discuss @brandonarbiter @kentquirk @jh-bate 

This is necessary because the two different kinds of "automatic" resumes (after 2 hours of LGS) for Medtronic pumps exhibit *different* behaviors (the `user-accepted` kind *will* resume a temp basal, while the `user-ignored` kind will *not*). In order for a user of our platform to be able to successfully retrospectively audit their data via the Tidepool data format, we *must* distinguish between these two.

That said, I'm not sure this is the best way to do it, although I do think it's simplest. The alternative is to create a new field on LGS suspend events to contain information about whether or not the user "accepted" (i.e., cleared at least one alarm) the LGS suspend or not.