### PR TITLE
Kjq/device and source

### DIFF
--- a/_docs/data-model/v1.md
+++ b/_docs/data-model/v1.md
@@ -31,16 +31,20 @@ An ISO8601 timestamp with a timezone offset.
 
 ### deviceId
 
-An indication of the device that generated the datum. This should be globally unique. A device make and model with serial number is a good value to include here. Examples:
+An indication of the device that generated the datum. This should be globally unique to this device. A device make and model with serial number is a good value to include here. Examples:
 
 * `"deviceId": "aviva-53543975796"` - It was taken from an Aviva BG meter with SN#53543975796
 * `"deviceId": "Insulet OmniPod 130028848"` -- It was taken from an Insulet OmniPod with serial number 130028848
 
+<<<<<<< Updated upstream
 ### uploadId
 
 The upload identifier; this field should be the uploadId of the corresponding [upload](upload) data record.
 
 Note that uploadId does not figure in the calculations of a record id. This is so that multiple uploads of the same records will compare equal.
+=======
+Please see the [docs for upload records](upload) for more information on deviceId.
+>>>>>>> Stashed changes
 
 ### source
 
@@ -107,7 +111,7 @@ If you disagree with the conversion algorithm, the HTTP API allows you to attach
 
 ## Duplicate Events
 
-If a duplicate event is submitted to the Tidepool platform, it will be ignored.  A duplicate event is defined as any event that results in the same generated id.  Ids are generated automatically by the system based on a different set of fields for each type of event, but at a minimum, a duplicate event will have the same timestamp.  
+If a duplicate event is submitted to the Tidepool platform, it will be ignored.  A duplicate event is defined as any event that results in the same generated id.  Ids are generated automatically by the system based on a different set of fields for each type of event, but at a minimum, a duplicate event will have the same timestamp.
 
 At some future date, we will have the ability to modify events.  At that time, there will be a special endpoint that allows for updating an event and in this case, it is expected that an id will be provided.
 
@@ -124,6 +128,6 @@ The basic tenet of our multi-versioned approach is that for all datums, we add t
 * `_sequenceId` - A "version" for the datum.  The original datum will have a `_sequenceId = 0`, the next modification will be 1, and so on
 * `_active` - A flag that enables "tombstoning" of events.  Or, the effective deletion of a datum without altering the history.
 
-By maintaining these fields and "stacking" events on top of each other we can always expose the "most recent" event, but still maintain the entire history of that event inside of our platform.  At the time of writing of this documentation, we have implemented this versioning methodology, but have not yet implemented endpoints that allow for accessing datums that are `_active == false`.  
+By maintaining these fields and "stacking" events on top of each other we can always expose the "most recent" event, but still maintain the entire history of that event inside of our platform.  At the time of writing of this documentation, we have implemented this versioning methodology, but have not yet implemented endpoints that allow for accessing datums that are `_active == false`.
 
 At some point in the future, there will be methods of accessing these datums and at that time, this documentation should be updated.  If you notice that we have the method of accessing but are currently reading this documentation, please at least alert someone to the fact that the docs are out of date and/or provide a pull request to the docs to bring them up to date.

--- a/_docs/data-model/v1.md
+++ b/_docs/data-model/v1.md
@@ -31,28 +31,23 @@ An ISO8601 timestamp with a timezone offset.
 
 ### deviceId
 
-An indication of the device that generated the datum. This should be globally unique to this device. A device make and model with serial number is a good value to include here. Examples:
+An indication of the device that generated the datum. This should be globally unique to this device and repeatable with each upload. A device make and model with serial number, shortened, is a good value to include here. Examples:
 
 * `"deviceId": "aviva-53543975796"` - It was taken from an Aviva BG meter with SN#53543975796
-* `"deviceId": "Insulet OmniPod 130028848"` -- It was taken from an Insulet OmniPod with serial number 130028848
+* `"deviceId": "InsOmn130028848"` -- It was taken from an Insulet OmniPod with serial number 130028848
 
-<<<<<<< Updated upstream
+Please see the [docs for upload records](upload) for more information on deviceId.
+
 ### uploadId
 
 The upload identifier; this field should be the uploadId of the corresponding [upload](upload) data record.
 
 Note that uploadId does not figure in the calculations of a record id. This is so that multiple uploads of the same records will compare equal.
-=======
-Please see the [docs for upload records](upload) for more information on deviceId.
->>>>>>> Stashed changes
 
-### source
+### source -- DEPRECATED
 
-The original source of the data. This should be sufficient version information to identify the specific software that did the upload. Examples:
+This field was originally defined in every data record. However, it has not proven useful and has proven to be confusing. It will still appear in older data records (where it was used to differentiate data that came from CareLink vs data that came from Tidepool's upload tools), but newer ones will not use it.
 
-* `"source": "uu-1.2.3_dexcom-1.0.3"` - It was provided by Tidepool's "Universal Uploader" version 1.2.3 running with the Dexcom driver version 1.0.3
-
-If you have any doubt about what to put in these fields, please contact Tidepool about what values would make the most sense to use.
 
 ### previous
 
@@ -92,6 +87,10 @@ There is a `creationTime` field that is auto-generated on all events. This is th
 ### modifiedTime
 
 There is a `modifiedTime` field that is auto-generated on all events that have been modified. This is the machine time of the most recent modification of the event.
+
+### payload
+
+Any object can have a "payload", which is itself an object with any number of unspecified fields. This is used to store device-specific data that doesn't rise to the level of standard, but that is useful to store. For example, the Dexcom G4 continuous glucose monitor displays "trend arrows", which are arrows that indicate the general direction of the change in glucose readings -- up, down, flat. This information is stored under payload.trend.
 
 ### annotations
 

--- a/_docs/data-model/v1/basal.md
+++ b/_docs/data-model/v1/basal.md
@@ -31,8 +31,7 @@ This represents an injection of a long-acting insulin.
   "insulin": name_of_insulin_used,
   "time": see_common_fields,
   "deviceId": see_common_fields,
-  "uploadId": see_common_fields,
-  "source": see_common_fields
+  "uploadId": see_common_fields
 }
 ~~~
 
@@ -63,7 +62,6 @@ This is a "scheduled" basal, it is a basal dosing that is operating according to
   "duration": number_of_milliseconds_this_basal_rate_will_be_in_effect,
   "time": see_common_fields,
   "deviceId": see_common_fields,
-  "source": see_common_fields,
   "previous": the_basal_event_that_would_have_been_previously_received,
   "suppressed": basal_events_not_being_delivered_because_this_one_is_active
 }
@@ -89,8 +87,7 @@ We start with a basal with no previous
   "rate": 0.7,
   "duration": 10800000,
   "time": "2014-01-01T00:00:00.000Z",
-  "deviceId": "1234",
-  "source": "example"
+  "deviceId": "1234"
 }
 ~~~
 
@@ -105,7 +102,6 @@ Then, we submit another basal with a previous
   "duration": 3600000,
   "time": "2014-01-01T03:00:00.000Z",
   "deviceId": "1234",
-  "source": "example",
   "previous": {
     "type": "basal",
     "deliveryType": "scheduled",
@@ -113,8 +109,7 @@ Then, we submit another basal with a previous
     "rate": 0.7,
     "duration": 10800000,
     "time": "2014-01-01T00:00:00.000Z",
-    "deviceId": "1234",
-    "source": "example"
+    "deviceId": "1234"
   }
 }
 ~~~
@@ -129,8 +124,7 @@ This will result in the Tidepool platform storing
     "rate": 0.7,
     "duration": 10800000,
     "time": "2014-01-01T00:00:00.000Z",
-    "deviceId": "1234",
-    "source": "example"
+    "deviceId": "1234"
 },{
   "type": "basal",
   "deliveryType": "scheduled",
@@ -138,8 +132,7 @@ This will result in the Tidepool platform storing
   "rate": 1.0,
   "duration": 3600000,
   "time": "2014-01-01T03:00:00.000Z",
-  "deviceId": "1234",
-  "source": "example"
+  "deviceId": "1234"
 }]
 ~~~
 
@@ -155,8 +148,7 @@ We start with a basal with no previous
   "rate": 0.7,
   "duration": 10800000,
   "time": "2014-01-01T00:00:00.000Z",
-  "deviceId": "1234",
-  "source": "example"
+  "deviceId": "1234"
 }
 ~~~
 
@@ -171,7 +163,6 @@ Then, we submit another basal with a previous
   "duration": 7200000,
   "time": "2014-01-01T04:00:00.000Z",
   "deviceId": "1234",
-  "source": "example",
   "previous": {
     "type": "basal",
     "deliveryType": "scheduled",
@@ -179,8 +170,7 @@ Then, we submit another basal with a previous
     "rate": 1.0,
     "duration": 3600000,
     "time": "2014-01-01T03:00:00.000Z",
-    "deviceId": "1234",
-    "source": "example"
+    "deviceId": "1234"
   }
 }
 ~~~
@@ -196,7 +186,6 @@ This will result in the Tidepool platform storing
     "duration": 10800000,
     "time": "2014-01-01T00:00:00.000Z",
     "deviceId": "1234",
-    "source": "example",
     "annotations": [{ "code": "basal/mismatched-series" }]
 },{
   "type": "basal",
@@ -205,8 +194,7 @@ This will result in the Tidepool platform storing
   "rate": 2.0,
   "duration": 7200000,
   "time": "2014-01-01T04:00:00.000Z",
-  "deviceId": "1234",
-  "source": "example"
+  "deviceId": "1234"
 }]
 ~~~
 
@@ -225,8 +213,7 @@ We start with a basal with no previous
   "rate": 0.7,
   "duration": 10800000,
   "time": "2014-01-01T00:00:00.000Z",
-  "deviceId": "1234",
-  "source": "example"
+  "deviceId": "1234"
 }
 ~~~
 
@@ -241,7 +228,6 @@ Then, we submit another basal with a previous
   "duration":7 14400000,
   "time": "2014-01-01T02:00:00.000Z",
   "deviceId": "1234",
-  "source": "example",
   "previous": {
     "type": "basal",
     "deliveryType": "scheduled",
@@ -249,8 +235,7 @@ Then, we submit another basal with a previous
     "rate": 0.7,
     "duration": 10800000,
     "time": "2014-01-01T00:00:00.000Z",
-    "deviceId": "1234",
-    "source": "example"
+    "deviceId": "1234"
   }
 }
 ~~~
@@ -266,8 +251,7 @@ This will result in the Tidepool platform storing
     "duration": 7200000,
     "expectedDuration": 14400000,
     "time": "2014-01-01T00:00:00.000Z",
-    "deviceId": "1234",
-    "source": "example"
+    "deviceId": "1234"
 },{
   "type": "basal",
   "deliveryType": "scheduled",
@@ -275,8 +259,7 @@ This will result in the Tidepool platform storing
   "rate": 0.8,
   "duration": 14400000,
   "time": "2014-01-01T02:00:00.000Z",
-  "deviceId": "1234",
-  "source": "example"
+  "deviceId": "1234"
 }]
 ~~~
 
@@ -294,7 +277,6 @@ Suspended basals are much the same as scheduled and temp basals:
       "duration": number_of_milliseconds_the_suspend_will_be_in_effect_if_known,
       "time": see_common_fields,
       "deviceId": see_common_fields,
-      "source": see_common_fields,
       "previous": the_basal_event_that_was_have_been_previously_received,
       "suppressed": basal_events_not_being_delivered_because_this_one_is_active
     }
@@ -317,7 +299,6 @@ Temp basals are much the same as scheduled basals:
       "duration": number_of_milliseconds_the_temporary_basal_will_be_in_effect,
       "time": see_common_fields,
       "deviceId": see_common_fields,
-      "source": see_common_fields,
       "previous": the_basal_event_that_would_have_been_previously_received,
       "suppressed": basal_events_not_being_delivered_because_this_one_is_active
     }

--- a/_docs/data-model/v1/basal.md
+++ b/_docs/data-model/v1/basal.md
@@ -26,12 +26,12 @@ This represents an injection of a long-acting insulin.
 {
   "type": "basal",
   "deliveryType": "injected",
-  "value": total_number_of_units_injected,
-  "duration": number_of_milliseconds_this_injection_is_expected_to_last,
-  "insulin": name_of_insulin_used,
-  "time": see_common_fields,
-  "deviceId": see_common_fields,
-  "uploadId": see_common_fields
+  "value": "total_number_of_units_injected",
+  "duration": "number_of_milliseconds_this_injection_is_expected_to_last",
+  "insulin": "name_of_insulin_used",
+  "time": "see_common_fields",
+  "deviceId": "see_common_fields",
+  "uploadId": "see_common_fields"
 }
 ~~~
 
@@ -57,13 +57,13 @@ This is a "scheduled" basal, it is a basal dosing that is operating according to
 {
   "type": "basal",
   "deliveryType": "scheduled",
-  "scheduleName": name_of_schedule_from_settings,
-  "rate": number_of_units_per_hour,
-  "duration": number_of_milliseconds_this_basal_rate_will_be_in_effect,
-  "time": see_common_fields,
-  "deviceId": see_common_fields,
-  "previous": the_basal_event_that_would_have_been_previously_received,
-  "suppressed": basal_events_not_being_delivered_because_this_one_is_active
+  "scheduleName": "name_of_schedule_from_settings",
+  "rate": "number_of_units_per_hour",
+  "duration": "number_of_milliseconds_this_basal_rate_will_be_in_effect",
+  "time": "see_common_fields",
+  "deviceId": "see_common_fields",
+  "previous": "the_basal_event_that_would_have_been_previously_received",
+  "suppressed": "basal_events_not_being_delivered_because_this_one_is_active"
 }
 ~~~
 
@@ -274,11 +274,11 @@ Suspended basals are much the same as scheduled and temp basals:
     {
       "type": "basal",
       "deliveryType": "suspend",
-      "duration": number_of_milliseconds_the_suspend_will_be_in_effect_if_known,
-      "time": see_common_fields,
-      "deviceId": see_common_fields,
-      "previous": the_basal_event_that_was_have_been_previously_received,
-      "suppressed": basal_events_not_being_delivered_because_this_one_is_active
+      "duration": "number_of_milliseconds_the_suspend_will_be_in_effect_if_known",
+      "time": "see_common_fields",
+      "deviceId": "see_common_fields",
+      "previous": "the_basal_event_that_was_have_been_previously_received",
+      "suppressed": "basal_events_not_being_delivered_because_this_one_is_active"
     }
 ~~~
 
@@ -294,13 +294,13 @@ Temp basals are much the same as scheduled basals:
     {
       "type": "basal",
       "deliveryType": "temp",
-      "rate": number_of_units_per_hour,
-      "percent": floating_point_percentage_of_suppressed_basal_that_should_be_delivered
-      "duration": number_of_milliseconds_the_temporary_basal_will_be_in_effect,
-      "time": see_common_fields,
-      "deviceId": see_common_fields,
-      "previous": the_basal_event_that_would_have_been_previously_received,
-      "suppressed": basal_events_not_being_delivered_because_this_one_is_active
+      "rate": "number_of_units_per_hour",
+      "percent": "floating_point_percentage_of_suppressed_basal_that_should_be_delivered"
+      "duration": "number_of_milliseconds_the_temporary_basal_will_be_in_effect",
+      "time": "see_common_fields",
+      "deviceId": "see_common_fields",
+      "previous": "the_basal_event_that_would_have_been_previously_received",
+      "suppressed": "basal_events_not_being_delivered_because_this_one_is_active"
     }
 ~~~
 

--- a/_docs/data-model/v1/bolus.md
+++ b/_docs/data-model/v1/bolus.md
@@ -28,8 +28,7 @@ An "injected" bolus is a bolus that was delivered via injection.  It is a single
   "insulin": name_of_insulin_used,
   "time": see_common_fields,
   "deviceId": see_common_fields,
-  "uploadId": see_common_fields,
-  "source": see_common_fields
+  "uploadId": see_common_fields
 }
 ~~~
 
@@ -48,8 +47,7 @@ A "normal" bolus is a one-time dose of insulin that is all delivered as quickly 
   "normal": number_of_units,
   "time": see_common_fields,
   "deviceId": see_common_fields,
-  "uploadId": see_common_fields,
-  "source": see_common_fields
+  "uploadId": see_common_fields
 }
 ~~~
 
@@ -66,7 +64,6 @@ It may be followed by a "completion" event that looks almost the same as the abo
   "time": see_common_fields,
   "deviceId": see_common_fields,
   "uploadId": see_common_fields,
-  "source": see_common_fields,
   "previous": bolus_event_that_is_now_completed
 }
 ~~~
@@ -84,8 +81,7 @@ If you first submit
   "normal": 2.0,
   "time": "2014-01-01T00:00:00.000Z",
   "deviceId": "1234",
-  "uploadId": "abc123def567",
-  "source": "example"
+  "uploadId": "abc123def567"
 }
 ~~~
 
@@ -99,14 +95,12 @@ you *may* also subsequently submit
   "time": "2014-01-01T00:02:00.000Z",
   "deviceId": "1234",
   "uploadId": "ccc111222333",
-  "source": "example",
   "previous": {
     "type": "bolus",
     "subType": "normal",
     "normal": 2.0,
     "time": "2014-01-01T00:00:00.000Z",
-    "deviceId": "1234",
-    "source": "example"
+    "deviceId": "1234"
   }
 }
 ~~~
@@ -119,8 +113,7 @@ In this case, whether you submit the follow-up event or not, the Tidepool platfo
   "subType": "normal",
   "normal": 2.0,
   "time": "2014-01-01T00:00:00.000Z",
-  "deviceId": "1234",
-  "source": "example"
+  "deviceId": "1234"
 }
 ~~~
 
@@ -135,8 +128,7 @@ If you start by submitting
   "subType": "normal",
   "normal": 2.0,
   "time": "2014-01-01T00:00:00.000Z",
-  "deviceId": "1234",
-  "source": "example"
+  "deviceId": "1234"
 }
 ~~~
 
@@ -149,14 +141,12 @@ and subsequently submit
   "normal": 1.0,
   "time": "2014-01-01T00:02:00.000Z",
   "deviceId": "1234",
-  "source": "example",
   "previous": {
     "type": "bolus",
     "subType": "normal",
     "normal": 2.0,
     "time": "2014-01-01T00:00:00.000Z",
-    "deviceId": "1234",
-    "source": "example"
+    "deviceId": "1234"
   }
 }
 ~~~
@@ -170,8 +160,7 @@ the follow-up event will update the original datum, changing the value of `norma
   "normal": 1.0,
   "expectedNormal": 2.0,
   "time": "2014-01-01T00:00:00.000Z",
-  "deviceId": "1234",
-  "source": "example"
+  "deviceId": "1234"
 }
 ~~~
 
@@ -188,8 +177,7 @@ A "square" bolus is a bolus that is delivered over some time duration, somewhat 
   "extended": number_of_units,
   "duration": milliseconds_over_which_the_bolus_should_be_delivered,
   "time": see_common_fields,
-  "deviceId": see_common_fields,
-  "source": see_common_fields
+  "deviceId": see_common_fields
 }
 ~~~
 
@@ -203,7 +191,6 @@ It is followed up with a "completion" event that looks the exact same as the abo
   "duration": milliseconds_over_which_the_bolus_was_delivered,
   "time": see_common_fields,
   "deviceId": see_common_fields,
-  "source": see_common_fields,
   "previous": bolus_event_that_is_now_completed
 }
 ~~~
@@ -226,8 +213,7 @@ A "dual/square" bolus is a bolus that starts out with a normal bolus and then co
   "extended": number_of_units_for_extended_delivery,
   "duration": milliseconds_over_which_the_extended_portion_should_be_delivered,
   "time": see_common_fields,
-  "deviceId": see_common_fields,
-  "source": see_common_fields
+  "deviceId": see_common_fields
 }
 ~~~
 
@@ -240,7 +226,6 @@ It may be followed up with a "completion" event that looks the exact same as the
   "normal": number_of_units
   "time": see_common_fields,
   "deviceId": see_common_fields,
-  "source": see_common_fields,
   "previous": initial_dual_square_bolus
 }
 ~~~
@@ -255,7 +240,6 @@ Which may also be followed up with a "completion" event that looks the exact sam
   "duration": milliseconds_over_which_the_extended_portion_was_delivered,
   "time": see_common_fields,
   "deviceId": see_common_fields,
-  "source": see_common_fields,
   "previous": bolus_event_that_is_now_completed
 }
 ~~~

--- a/_docs/data-model/v1/bolus.md
+++ b/_docs/data-model/v1/bolus.md
@@ -24,11 +24,11 @@ An "injected" bolus is a bolus that was delivered via injection.  It is a single
 {
   "type": "bolus",
   "subType": "injected",
-  "value": number_of_units_injected,
-  "insulin": name_of_insulin_used,
-  "time": see_common_fields,
-  "deviceId": see_common_fields,
-  "uploadId": see_common_fields
+  "value": "number_of_units_injected",
+  "insulin": "name_of_insulin_used",
+  "time": "see_common_fields",
+  "deviceId": "see_common_fields",
+  "uploadId": "see_common_fields"
 }
 ~~~
 
@@ -44,10 +44,10 @@ A "normal" bolus is a one-time dose of insulin that is all delivered as quickly 
 {
   "type": "bolus",
   "subType": "normal",
-  "normal": number_of_units,
-  "time": see_common_fields,
-  "deviceId": see_common_fields,
-  "uploadId": see_common_fields
+  "normal": "number_of_units",
+  "time": "see_common_fields",
+  "deviceId": "see_common_fields",
+  "uploadId": "see_common_fields"
 }
 ~~~
 
@@ -60,11 +60,11 @@ It may be followed by a "completion" event that looks almost the same as the abo
 {
   "type": "bolus",
   "subType": "normal",
-  "normal": number_of_units,
-  "time": see_common_fields,
-  "deviceId": see_common_fields,
-  "uploadId": see_common_fields,
-  "previous": bolus_event_that_is_now_completed
+  "normal": "number_of_units",
+  "time": "see_common_fields",
+  "deviceId": "see_common_fields",
+  "uploadId": "see_common_fields",
+  "previous": "bolus_event_that_is_now_completed"
 }
 ~~~
 
@@ -174,10 +174,10 @@ A "square" bolus is a bolus that is delivered over some time duration, somewhat 
 {
   "type": "bolus",
   "subType": "square",
-  "extended": number_of_units,
-  "duration": milliseconds_over_which_the_bolus_should_be_delivered,
-  "time": see_common_fields,
-  "deviceId": see_common_fields
+  "extended": "number_of_units",
+  "duration": "milliseconds_over_which_the_bolus_should_be_delivered",
+  "time": "see_common_fields",
+  "deviceId": "see_common_fields"
 }
 ~~~
 
@@ -187,11 +187,11 @@ It is followed up with a "completion" event that looks the exact same as the abo
 {
   "type": "bolus",
   "subType": "square",
-  "extended": number_of_units,
-  "duration": milliseconds_over_which_the_bolus_was_delivered,
-  "time": see_common_fields,
-  "deviceId": see_common_fields,
-  "previous": bolus_event_that_is_now_completed
+  "extended": "number_of_units",
+  "duration": "milliseconds_over_which_the_bolus_was_delivered",
+  "time": "see_common_fields",
+  "deviceId": "see_common_fields",
+  "previous": "bolus_event_that_is_now_completed"
 }
 ~~~
 
@@ -209,11 +209,11 @@ A "dual/square" bolus is a bolus that starts out with a normal bolus and then co
 {
   "type": "bolus",
   "subType": "dual/square",
-  "normal": number_of_units,
-  "extended": number_of_units_for_extended_delivery,
-  "duration": milliseconds_over_which_the_extended_portion_should_be_delivered,
-  "time": see_common_fields,
-  "deviceId": see_common_fields
+  "normal": "number_of_units",
+  "extended": "number_of_units_for_extended_delivery",
+  "duration": "milliseconds_over_which_the_extended_portion_should_be_delivered",
+  "time": "see_common_fields",
+  "deviceId": "see_common_fields"
 }
 ~~~
 
@@ -223,10 +223,10 @@ It may be followed up with a "completion" event that looks the exact same as the
 {
   "type": "bolus",
   "subType": "normal",
-  "normal": number_of_units
-  "time": see_common_fields,
-  "deviceId": see_common_fields,
-  "previous": initial_dual_square_bolus
+  "normal": "number_of_units"
+  "time": "see_common_fields",
+  "deviceId": "see_common_fields",
+  "previous": "initial_dual_square_bolus"
 }
 ~~~
 
@@ -236,11 +236,11 @@ Which may also be followed up with a "completion" event that looks the exact sam
 {
   "type": "bolus",
   "subType": "square",
-  "extended": number_of_units,
-  "duration": milliseconds_over_which_the_extended_portion_was_delivered,
-  "time": see_common_fields,
-  "deviceId": see_common_fields,
-  "previous": bolus_event_that_is_now_completed
+  "extended": "number_of_units",
+  "duration": "milliseconds_over_which_the_extended_portion_was_delivered",
+  "time": "see_common_fields",
+  "deviceId": "see_common_fields",
+  "previous": "bolus_event_that_is_now_completed"
 }
 ~~~
 

--- a/_docs/data-model/v1/cbg.md
+++ b/_docs/data-model/v1/cbg.md
@@ -11,11 +11,11 @@ CBG represents blood glucose from a continuous glucose monitor.  These events ar
 ~~~json
 {
   "type": "cbg",
-  "value": bg_value_from_cgm,
-  "isig": optional_interstitial_fluid_value_from_cgm,
-  "time": see_common_fields,
-  "deviceId": see_common_fields,
-  "uploadId": see_common_fields
+  "value": "bg_value_from_cgm",
+  "isig": "optional_interstitial_fluid_value_from_cgm",
+  "time": "see_common_fields",
+  "deviceId": "see_common_fields",
+  "uploadId": "see_common_fields"
 }
 ~~~
 

--- a/_docs/data-model/v1/cbg.md
+++ b/_docs/data-model/v1/cbg.md
@@ -15,8 +15,7 @@ CBG represents blood glucose from a continuous glucose monitor.  These events ar
   "isig": optional_interstitial_fluid_value_from_cgm,
   "time": see_common_fields,
   "deviceId": see_common_fields,
-  "uploadId": see_common_fields,
-  "source": see_common_fields
+  "uploadId": see_common_fields
 }
 ~~~
 

--- a/_docs/data-model/v1/device-meta.md
+++ b/_docs/data-model/v1/device-meta.md
@@ -29,7 +29,6 @@ A status event is used to represent the status of a pump.  Specifically, this is
   "duration": max_duration_of_status_if_known,
   "deviceId": see_common_fields,
   "uploadId": see_common_fields,
-  "source": see_common_fields,
   "previous": previously_active_status_event
 }
 ~~~

--- a/_docs/data-model/v1/device-meta.md
+++ b/_docs/data-model/v1/device-meta.md
@@ -23,13 +23,13 @@ A status event is used to represent the status of a pump.  Specifically, this is
 {
   "type": "deviceMeta",
   "subType": "status",
-  "status": suspended_or_resumed,
-  "reason": indication_of_why,
-  "time": see_common_fields,
-  "duration": max_duration_of_status_if_known,
-  "deviceId": see_common_fields,
-  "uploadId": see_common_fields,
-  "previous": previously_active_status_event
+  "status": "suspended_or_resumed",
+  "reason": "indication_of_why",
+  "time": "see_common_fields",
+  "duration": "max_duration_of_status_if_known",
+  "deviceId": "see_common_fields",
+  "uploadId": "see_common_fields",
+  "previous": "previously_active_status_event"
 }
 ~~~
 

--- a/_docs/data-model/v1/food.md
+++ b/_docs/data-model/v1/food.md
@@ -18,8 +18,7 @@ A food event looks like
   "fat": grams_of_fat,
   "location": location_of_meal,
   "name": name_of_food,
-  "uploadId": see_common_fields,
-  "source": see_common_fields
+  "uploadId": see_common_fields
 }
 ~~~
 

--- a/_docs/data-model/v1/food.md
+++ b/_docs/data-model/v1/food.md
@@ -12,13 +12,13 @@ A food event looks like
 ~~~json
 {
   "type": "food",
-  "time": see_common_fields,
-  "carbs": grams_of_carbs,
-  "protein": grams_of_protein,
-  "fat": grams_of_fat,
-  "location": location_of_meal,
-  "name": name_of_food,
-  "uploadId": see_common_fields
+  "time": "see_common_fields",
+  "carbs": "grams_of_carbs",
+  "protein": "grams_of_protein",
+  "fat": "grams_of_fat",
+  "location": "location_of_meal",
+  "name": "name_of_food",
+  "uploadId": "see_common_fields"
 }
 ~~~
 

--- a/_docs/data-model/v1/notes.md
+++ b/_docs/data-model/v1/notes.md
@@ -12,16 +12,16 @@ Note events look like:
 ~~~json
 {
   "type": "note",
-  "shortText": short_text_of_note,
-  "text": text_of_note,
-  "creatorId": userId of the account that created the note
-  "reference": event_to_which_this_note_refers,
-  "time": time_this_message_refers_to,
-  "displayTime": optional_time_to_display_when_rendered,
-  "createdTime": see_provenance_fields,
-  "modifiedTime": see_provenance_fields,
-  "deviceId": see_common_fields,
-  "uploadId": see_common_fields
+  "shortText": "short_text_of_note",
+  "text": "text_of_note",
+  "creatorId": "userId of the account that created the not"e
+  "reference": "event_to_which_this_note_refers",
+  "time": "time_this_message_refers_to",
+  "displayTime": "optional_time_to_display_when_rendered",
+  "createdTime": "see_provenance_fields",
+  "modifiedTime": "see_provenance_fields",
+  "deviceId": "see_common_fields",
+  "uploadId": "see_common_fields"
 }
 ~~~
 

--- a/_docs/data-model/v1/notes.md
+++ b/_docs/data-model/v1/notes.md
@@ -21,8 +21,7 @@ Note events look like:
   "createdTime": see_provenance_fields,
   "modifiedTime": see_provenance_fields,
   "deviceId": see_common_fields,
-  "uploadId": see_common_fields,
-  "source": see_common_fields
+  "uploadId": see_common_fields
 }
 ~~~
 

--- a/_docs/data-model/v1/settings.md
+++ b/_docs/data-model/v1/settings.md
@@ -14,7 +14,6 @@ A settings object represents the settings of a pump.  A settings object sent int
     "time": see_common_fields,
     "deviceId": see_common_fields,
     "uploadId": see_common_fields,
-    "source": see_common_fields
     "activeSchedule": currently_active_basal_schedule_name,
     "units": see_below,
     "basalSchedules": see_below,
@@ -41,7 +40,7 @@ A settings object represents the settings of a pump.  A settings object sent int
 
 ~~~json
     {
-        "standard": [ 
+        "standard": [
           { "rate": 0.8, "start": 0 },
           { "rate": 0.75, "start": 3600000 },
           ...
@@ -56,7 +55,7 @@ A settings object represents the settings of a pump.  A settings object sent int
 
 Where:
 
-* `rate` is the basal rate 
+* `rate` is the basal rate
 * `start` is the millisecond offset from midnight that day, representing when the rate should take effect
 
 ### carbRatio
@@ -70,9 +69,9 @@ Where:
       ...
     ]
 ~~~
- 
-Where 
-* `amount` is the units of carbs per unit of insulin 
+
+Where
+* `amount` is the units of carbs per unit of insulin
 * `start` is the millisecond offset from midnight that day, representing when the ratio should take effect
 
 ### insulinSensitivity
@@ -89,7 +88,7 @@ Where
 
 Where:
 
-* `amount` is the expected decrease in bg per unit of insulin 
+* `amount` is the expected decrease in bg per unit of insulin
 * `start` is the millisecond offset from midnight that day, representing when the sensitivity value should take effect
 
 ### bgTarget

--- a/_docs/data-model/v1/smbg.md
+++ b/_docs/data-model/v1/smbg.md
@@ -11,10 +11,10 @@ SMBG represents blood glucose from a finger prick or other "self-monitoring" met
 ~~~json
 {
   "type": "smbg",
-  "value": bg_value_from_self_monitoring_device,
-  "time": see_common_fields,
-  "deviceId": see_common_fields,
-  "uploadId": see_common_fields
+  "value": "bg_value_from_self_monitoring_device",
+  "time": "see_common_fields",
+  "deviceId": "see_common_fields",
+  "uploadId": "see_common_fields"
 }
 ~~~
 

--- a/_docs/data-model/v1/smbg.md
+++ b/_docs/data-model/v1/smbg.md
@@ -14,8 +14,7 @@ SMBG represents blood glucose from a finger prick or other "self-monitoring" met
   "value": bg_value_from_self_monitoring_device,
   "time": see_common_fields,
   "deviceId": see_common_fields,
-  "uploadId": see_common_fields,
-  "source": see_common_fields
+  "uploadId": see_common_fields
 }
 ~~~
 

--- a/_docs/data-model/v1/upload.md
+++ b/_docs/data-model/v1/upload.md
@@ -90,7 +90,7 @@ Again, for new devices please contact Tidepool so we can standardize on a name.
 
 Manufacturers often identify devices in a series of similar devices, each with a different model identification -- for example, Medtronic has the Paradigm Revel 523 and Paradigm Revel 723 pumps. Therefore, we have two levels of identifier. In this case, `deviceSeries` would be `"Paradigm Revel"` and `deviceModel` would be `523` or `723`.
 
-For manufacturers who don't have multiple levels, use the deviceSeries field and set the deviceModel field to an empty string (do not omit it).
+For manufacturers who don't have multiple levels, use the deviceModel field and set the deviceSeries field to an empty string (do not omit it).
 
 ### deviceSerialNumber
 

--- a/_docs/data-model/v1/upload.md
+++ b/_docs/data-model/v1/upload.md
@@ -22,11 +22,10 @@ These events are point-in-time and look like
   "version": "version_of_uploader",
   "uploadId": "unique_id",
   "byUser": "userId_of_the_uploading user"
-  "deviceType": "type_of_device",
-  "deviceManufacturer": "name_of_manufacturer",
-  "deviceSeries": "mfr_device_series",
-  "deviceModel": "mfr_device_model_within_a_series",
-  "deviceSerialNumber": "serial_number"
+  "deviceTags": ["tags_relating_to_device_features"...],
+  "deviceManufacturers": ["name_of_manufacturer"...],
+  "deviceModel": "mfr_device_model",
+  "deviceSerialNumber": "serial_number",
   "deviceId": "see_common_fields",
   "createdTime": "see_common_fields",
   "modifiedTime": "see_common_fields"
@@ -61,43 +60,53 @@ The Tidepool platform supports the idea that a user other than the data owner ma
 
 ## device information
 
-### deviceType
-This is the broad category of the device. In general, it should be one of the following:
+For all of the fields under device information, we are trying to provide a basic taxonomy and standards so that it will be easy to query for specific device types or classes.
 
-* `"pump"` (for insulin pumps)
+Thus, if you are storing information in the Tidepool platform and are unsure of what information should go here, please contact us so we can help you and maintain a high standard of data quality.
+
+### deviceTags
+This is a list of broad attributes that can be applied to the device. It is an array of individual string values. Please use exactly the attributes below if they apply, in addition to any others that are appropriate:
+
+* `"insulin-pump"` (for insulin pumps)
 * `"cgm"` (for continuous glucose monitors)
-* `"pump-cgm"` (for pumps integrated with a cgm)
 * `"bgm"` (for blood glucose meters that are not continuous meters)
-* `"pen"` (for insulin injection devices)
+* `"fgm"` (for 'flash' glucose meters that are not continuous meters but able to read on demand)
+* `"pen"` (for insulin injection devices that record the doses)
 * `"manual"` (for manually entered data)
 
-For devices that do not fit in one of these categories, please contact Tidepool so we can standardize on a good name.
+Integrated devices or multifunction devices should use multiple tags as appropriate. For devices that do not fit in these categories, please contact Tidepool so we can standardize on a good tag.
 
-### deviceManufacturer
+### deviceBrand
 
-This is the name of the device manufacturer. We are trying to standardize this field as well, so please use exactly the following names:
+This is an array containing the name or names of the device manufacturers. We are trying to standardize this field as well, so please use exactly the following names:
 
     Abbott
     Asante
     Dexcom
     Insulet
     Medtronic
-    OneTouch
+    LifeScan
 
 Again, for new devices please contact Tidepool so we can standardize on a name.
 
-### deviceSeries and deviceModel
+### deviceModel
 
-Manufacturers often identify devices in a series of similar devices, each with a different model identification -- for example, Medtronic has the Paradigm Revel 523 and Paradigm Revel 723 pumps. Therefore, we have two levels of identifier. In this case, `deviceSeries` would be `"Paradigm Revel"` and `deviceModel` would be `523` or `723`.
+This is the name the manufacturer uses to identify the device. Examples might be:
 
-For manufacturers who don't have multiple levels, use the deviceModel field and set the deviceSeries field to an empty string (do not omit it).
+    MiniMed 530G
+    G4
+    FreeStyle Precision Xtra
+
+Again, this is an array so that devices that are created in partnership between multiple manufacturers can be properly specified.
 
 ### deviceSerialNumber
 
 If the serial number of the device is available, put it here as a string, even if it's entirely numeric. If the serial number is not available, store it as a blank string.
 
+
 ### deviceId
-The deviceId should be a string that is sufficient to uniquely identify the device and which will be reused every time data is uploaded from this device. Since the deviceId shows up in every data element, it probably wants to be on the shorter side, so we suggest something like the first 3 characters of manufacturer, series, and model, followed by the serial number. For example: `DexG41123449542`.
+
+The deviceId should be a string that is sufficient to uniquely identify the device and which will be reused every time data is uploaded from this device. Since the deviceId shows up in every data element, it probably wants to be on the shorter side, so we suggest something like the first few characters of the name of the device, followed by the serial number. For example: `DexG4-1123449542`.
 
 
 

--- a/_docs/data-model/v1/upload.md
+++ b/_docs/data-model/v1/upload.md
@@ -22,8 +22,8 @@ These events are point-in-time and look like
   "version": "version_of_uploader",
   "uploadId": "unique_id",
   "byUser": "userId_of_the_uploading user"
-  "deviceTags": ["tags_relating_to_device_features"...],
-  "deviceManufacturer": "name_of_manufacturer",
+  "deviceTags": ["tag_relating_to_device_features", "..."],
+  "deviceManufacturers": ["name_of_manufacturer", "..."],
   "deviceModel": "mfr_device_model",
   "deviceSerialNumber": "serial_number",
   "deviceId": "see_common_fields",
@@ -76,11 +76,12 @@ This is a list of broad attributes that can be applied to the device. It is an a
 
 Integrated devices or multifunction devices should use multiple tags as appropriate. For example, the Animas Vibe combo insulin delivery and CGM system would have tags `insulin-pump` and `cgm`. For devices that do not fit in these categories, please contact Tidepool so we can standardize on a good tag.
 
-### deviceManufacturer
+### deviceManufacturers
 
-This is the name of the device manufacturer. We are trying to standardize this field, so please use exactly the following names:
+This is the name or names of the device manufacturer(s), as an array. It may be more than one for devices that are joint projects of multiple organizations; again, the Animas Vibe would have `["Animas", "Dexcom"]` here. We are trying to standardize this field, so please use exactly the following names:
 
     Abbott
+    Animas
     Asante
     Dexcom
     Insulet

--- a/_docs/data-model/v1/upload.md
+++ b/_docs/data-model/v1/upload.md
@@ -23,7 +23,7 @@ These events are point-in-time and look like
   "uploadId": "unique_id",
   "byUser": "userId_of_the_uploading user"
   "deviceTags": ["tags_relating_to_device_features"...],
-  "deviceManufacturers": ["name_of_manufacturer"...],
+  "deviceManufacturer": "name_of_manufacturer",
   "deviceModel": "mfr_device_model",
   "deviceSerialNumber": "serial_number",
   "deviceId": "see_common_fields",
@@ -74,11 +74,11 @@ This is a list of broad attributes that can be applied to the device. It is an a
 * `"pen"` (for insulin injection devices that record the doses)
 * `"manual"` (for manually entered data)
 
-Integrated devices or multifunction devices should use multiple tags as appropriate. For devices that do not fit in these categories, please contact Tidepool so we can standardize on a good tag.
+Integrated devices or multifunction devices should use multiple tags as appropriate. For example, the Animas Vibe combo insulin delivery and CGM system would have tags `insulin-pump` and `cgm`. For devices that do not fit in these categories, please contact Tidepool so we can standardize on a good tag.
 
-### deviceBrand
+### deviceManufacturer
 
-This is an array containing the name or names of the device manufacturers. We are trying to standardize this field as well, so please use exactly the following names:
+This is the name of the device manufacturer. We are trying to standardize this field, so please use exactly the following names:
 
     Abbott
     Asante
@@ -94,10 +94,8 @@ Again, for new devices please contact Tidepool so we can standardize on a name.
 This is the name the manufacturer uses to identify the device. Examples might be:
 
     MiniMed 530G
-    G4
+    G4 Platinum
     FreeStyle Precision Xtra
-
-Again, this is an array so that devices that are created in partnership between multiple manufacturers can be properly specified.
 
 ### deviceSerialNumber
 

--- a/_docs/data-model/v1/upload.md
+++ b/_docs/data-model/v1/upload.md
@@ -21,7 +21,7 @@ These events are point-in-time and look like
   "timezone": "name_of_timezone",
   "version": "version_of_uploader",
   "uploadId": "unique_id",
-  "byUser": "userId_of_the_uploading user"
+  "byUser": "userId_of_the_uploading user",
   "deviceTags": ["tag_relating_to_device_features", "..."],
   "deviceManufacturers": ["name_of_manufacturer", "..."],
   "deviceModel": "mfr_device_model",

--- a/_docs/data-model/v1/upload.md
+++ b/_docs/data-model/v1/upload.md
@@ -22,10 +22,14 @@ These events are point-in-time and look like
   "version": "version_of_uploader",
   "uploadId": "unique_id",
   "byUser": "userId_of_the_uploading user"
-  "createdTime": "see_common_fields",
-  "modifiedTime": "see_common_fields",
-  "source": "see_common_fields",
+  "deviceType": "type_of_device",
+  "deviceManufacturer": "name_of_manufacturer",
+  "deviceSeries": "mfr_device_series",
+  "deviceModel": "mfr_device_model_within_a_series",
+  "deviceSerialNumber": "serial_number"
   "deviceId": "see_common_fields",
+  "createdTime": "see_common_fields",
+  "modifiedTime": "see_common_fields"
 }
 ~~~
 
@@ -35,7 +39,7 @@ The timezone is the *name* of the timezone selected by the user for the upload. 
 
 ### version
 
-This is the version of the uploader that was used to parse the data for the upload session, e.g. `"version":"chrome uploader v0.9.0"`. The intention is that then if we have a bug with a particular version of the uploader we can trace all the data that was processed with that version.
+This is the version of the uploader software (whether Tidepool's or someone else's) that was used to parse the data for the upload session, e.g. `"version":"chrome uploader v0.9.0"`. The intention is that then if there is a bug with a particular version of software it will be possible to identify all the data that was processed with that version.
 
 ### uploadId
 
@@ -45,7 +49,7 @@ The uploadId is generated as a hash from several values:
 * The deviceId for the upload data
 * The current session token
 
-The point is that the uploadId should change for each device, for each upload session. 
+The point is that the uploadId should change for each device, for each upload session.
 
 For situations where we are uploading data extracted from a non-device source, such as when we scrape data from third party websites that do not support a data API, the uploadId should likely be consistent for an entire session, even if that session contains data from multiple physical devices.
 
@@ -54,6 +58,48 @@ At some point, we may support real-time monitoring of devices, in which case the
 ### byUser
 
 The Tidepool platform supports the idea that a user other than the data owner may have upload permissions (for example, a clinic or a parent). The byUser field should be the actual userId of the user doing the upload. This field will be stored in encrypted form in the actual data stream as it constitutes PII.
+
+## device information
+
+### deviceType
+This is the broad category of the device. In general, it should be one of the following:
+
+* `"pump"` (for insulin pumps)
+* `"cgm"` (for continuous glucose monitors)
+* `"pump-cgm"` (for pumps integrated with a cgm)
+* `"bgm"` (for blood glucose meters that are not continuous meters)
+* `"pen"` (for insulin injection devices)
+* `"manual"` (for manually entered data)
+
+For devices that do not fit in one of these categories, please contact Tidepool so we can standardize on a good name.
+
+### deviceManufacturer
+
+This is the name of the device manufacturer. We are trying to standardize this field as well, so please use exactly the following names:
+
+    Abbott
+    Asante
+    Dexcom
+    Insulet
+    Medtronic
+    OneTouch
+
+Again, for new devices please contact Tidepool so we can standardize on a name.
+
+### deviceSeries and deviceModel
+
+Manufacturers often identify devices in a series of similar devices, each with a different model identification -- for example, Medtronic has the Paradigm Revel 523 and Paradigm Revel 723 pumps. Therefore, we have two levels of identifier. In this case, `deviceSeries` would be `"Paradigm Revel"` and `deviceModel` would be `523` or `723`.
+
+For manufacturers who don't have multiple levels, use the deviceSeries field and set the deviceModel field to an empty string (do not omit it).
+
+### deviceSerialNumber
+
+If the serial number of the device is available, put it here as a string, even if it's entirely numeric. If the serial number is not available, store it as a blank string.
+
+### deviceId
+The deviceId should be a string that is sufficient to uniquely identify the device and which will be reused every time data is uploaded from this device. Since the deviceId shows up in every data element, it probably wants to be on the shorter side, so we suggest something like the first 3 characters of manufacturer, series, and model, followed by the serial number. For example: `DexG41123449542`.
+
+
 
 ## Storage/Output Format
 

--- a/_docs/data-model/v1/wizard.md
+++ b/_docs/data-model/v1/wizard.md
@@ -27,7 +27,6 @@ Wizard events are point-in-time and look like
   "time": see_common_fields,
   "deviceId": see_common_fields,
   "uploadId": see_common_fields,
-  "source": see_common_fields,
   "bolus": bolus_event_resulting_from_wizard_if_exists
 }
 ~~~
@@ -41,7 +40,7 @@ Wizard events are point-in-time and look like
 * `insulinCarbRatio` is the number of mg of carbohydrates that one unit of insulin is expected to cover
 * `insulinSensitivity` is the amount that one unit of insulin is expected to decrease blood glucose.  This is converted to mmol/l based on a `units` field.
 * `bgTarget` is the complex representation of the target blood glucose.  It can be  varying schemas that should align with the schemas in the [settings object](../settings) except there is no `start` field.
-* `payload` is an object of arbitrary fields that will be stored alongside the wizard event.  An example of things that might be stored is:
+* `payload` is an object of arbitrary fields that will be stored alongside the wizard event. This is just an instance of the common field `payload`. An example of things that might be stored is:
 
 ~~~json
 {


### PR DESCRIPTION
@jebeck This removes source as a standard field in every record (thinking about it, I just couldn't see a use for a field like this). Yes, I checked that it's not used in jellyfish as part of the record ID. 

It also adds a bunch of device data to the upload record. I thought about putting them all as a subobject and decided I didn't really like that. 

Finally, it changes the recommendation on what "deviceId" should be. 

I will follow up with a jellyfish PR for all of this.