### PR TITLE
BG changes

### DIFF
--- a/_docs/data-model/v1/annotations.md
+++ b/_docs/data-model/v1/annotations.md
@@ -40,6 +40,9 @@ We document our known annotations below, but we do not limit the set of annotati
 * `status/incomplete-tuple` happens when a `deviceMeta` `status` event is sent in and never completed.  See the [Device Metadata](device-meta) page for more details.
 
 
+* `bg/out-of-range` happens when a blood-glucose sensing device reads LOW or HIGH instead of a numerical value. We store a value of +/-1 from the max or min value (this will vary depending on device) and apply this annotation to expose the change.
+
+
 * `status/unknown-previous` happens when a `deviceMeta` `status` event is sent in with a `previous` field that doesn't reference an object in the Tidepool platform.  Accompanied by an `id` field:
     * `id` the expected id of the previous event as specified in the `previous` field on the event submitted to the Tidepool platform.  This might be null or just not exist if there wasn't a `previous` field provided on the submitted event.
 

--- a/_docs/data-model/v1/annotations.md
+++ b/_docs/data-model/v1/annotations.md
@@ -18,7 +18,7 @@ An annotation object has one required field, `code`, and can have any number of 
 is valid.  Also
 
 ~~~json
-    { "code": "bg/out-of-range", "threshold": 40 }
+    { "code": "bg/out-of-range", "threshold": 40, "value": "low" }
 ~~~
 
 Could also be valid.  That is, the idea is that the annotation can optionally provide some information that helps when explaining what went wrong.  The fabricated example above would be for a CBG reading that ends up below 40 but the CGM can only read down to 40.  If there were another CGM that could read down to 25, then that CGM would set the threshold value to 25 instead of 40.

--- a/_docs/data-model/v1/annotations.md
+++ b/_docs/data-model/v1/annotations.md
@@ -18,7 +18,7 @@ An annotation object has one required field, `code`, and can have any number of 
 is valid.  Also
 
 ~~~json
-    { "code": "cbg/below-testable-threshold", "threshold": 40 }
+    { "code": "bg/out-of-range", "threshold": 40 }
 ~~~
 
 Could also be valid.  That is, the idea is that the annotation can optionally provide some information that helps when explaining what went wrong.  The fabricated example above would be for a CBG reading that ends up below 40 but the CGM can only read down to 40.  If there were another CGM that could read down to 25, then that CGM would set the threshold value to 25 instead of 40.
@@ -40,8 +40,15 @@ We document our known annotations below, but we do not limit the set of annotati
 * `status/incomplete-tuple` happens when a `deviceMeta` `status` event is sent in and never completed.  See the [Device Metadata](device-meta) page for more details.
 
 
-* `bg/out-of-range` happens when a blood-glucose sensing device reads LOW or HIGH instead of a numerical value. We store a value of +/-1 from the max or min value (this will vary depending on device) and apply this annotation to expose the change.
+* `bg/out-of-range` happens when a blood-glucose sensing device reads LOW or HIGH instead of a numerical value. We store a value of +/-1 from the max or min value (this will vary depending on device) and apply this annotation to expose the change. The non-numerical display value and threshold, if available, should also be included in the annotation object:
 
+~~~json
+{
+    "code": "bg/out-of-range",
+    "threshold": 20,
+    "value": "low"
+}
+~~~
 
 * `status/unknown-previous` happens when a `deviceMeta` `status` event is sent in with a `previous` field that doesn't reference an object in the Tidepool platform.  Accompanied by an `id` field:
     * `id` the expected id of the previous event as specified in the `previous` field on the event submitted to the Tidepool platform.  This might be null or just not exist if there wasn't a `previous` field provided on the submitted event.

--- a/_docs/data-model/v1/smbg.md
+++ b/_docs/data-model/v1/smbg.md
@@ -11,6 +11,7 @@ SMBG represents blood glucose from a finger prick or other "self-monitoring" met
 ~~~json
 {
   "type": "smbg",
+  "subType": "optional_entry_type_info",
   "value": "bg_value_from_self_monitoring_device",
   "time": "see_common_fields",
   "deviceId": "see_common_fields",
@@ -18,7 +19,15 @@ SMBG represents blood glucose from a finger prick or other "self-monitoring" met
 }
 ~~~
 
+## subType
 
-## Storage/Output Format
+The Tidepool platform ingests `smbg` records from many more sources than just blood glucose meters - e.g., insulin pumps (with or without linked meters), and manual logging. The `subType` field records more information about the type of `smbg` record given its source. The possible values, at present, are the following:
+
+- `manual`
+- `linked`
+
+Values that come directly from a blood glucose meter can either contain an empty string for the `subType` or omit the field entirely.
+
+### Storage/Output Format
 
 The storage and output format for this datum is exactly what was initially ingested.  There are no modifications performed


### PR DESCRIPTION
Two things in this PR:
- an annotation code for out-of-range BG values
- a `subType` field on `smbg` values for storing info about whether the datum came from a linked meter, manual logging, etc.