### PR TITLE
Tidepool API organization and adding information

### DIFF
--- a/_docs/tidepool-api/downloading.md
+++ b/_docs/tidepool-api/downloading.md
@@ -1,0 +1,111 @@
+---
+layout: defaults
+title: Tidepool API - Downloading
+published: true
+---
+
+# Tidepool API: Downloading Health Data
+
+For other parts of the API, including logging in and uploading data, navigate back or to the [API walkthrough](/tidepool-api/index). 
+
+
+## Health data
+
+[Link to format documentation]
+
+### Get data
+
+[For Care Team, for date range]
+
+
+## Notes
+
+### Get notes
+
+Top level notes (i.e. no comments) within an optional date range
+
+```
+GET /message/notes/:groupid?starttime&endtime
+x-tidepool-session-token: <token>
+```
+
+Response:
+
+```
+200 OK
+```
+
+```javascript
+messages: [
+ {
+    id: '123',
+    parentmessage : null,
+    userid: '777',
+    user: { "fullName": "Mary Smith" }, //users public profile
+    groupid: '777',
+    timestamp: '2013-11-28T23:07:40+00:00',
+    createdtime: '2013-11-28T23:07:40+00:00',
+    messagetext: 'In three words I can sum up everything I have learned about life: it goes on.'
+  },
+  {
+    id: '456',
+    parentmessage:null,
+    user: { "fullName": "Bob Smith" }, //users public profile
+    userid: '112',
+    groupid: '777',
+    timestamp: '2013-11-29T23:05:40+00:00',
+    createdtime: '2013-11-28T23:07:40+00:00',
+    messagetext: 'Second message.'
+  }
+]
+```
+
+### Get messages
+
+All messages within an optional date range
+
+```
+GET /message/all/:groupid?starttime&endtime
+x-tidepool-session-token: <token>
+```
+
+Response:
+
+```
+200 OK
+```
+
+```javascript
+messages: [
+ {
+    id: '123',
+    parentmessage : null,
+    userid: '777',
+    user: { "fullName": "Mary Smith" }, //users public profile
+    groupid: '777',
+    timestamp: '2013-11-28T23:07:40+00:00',
+    createdtime: '2013-11-28T23:07:40+00:00',
+    messagetext: 'In three words I can sum up everything I have learned about life: it goes on.'
+  },
+  {
+    id: '456',
+    parentmessage:'123',
+    user: { "fullName": "Bob Smith" },
+    userid: '112',
+    groupid: '777',
+    timestamp: '2013-11-29T23:05:40+00:00',
+    createdtime: '2013-11-28T23:07:40+00:00',
+    messagetext: 'A comment.'
+  },
+  {
+    id: '789',
+    parentmessage: null,
+    user: { "fullName": "Bob Smith" },
+    userid: '112',
+    groupid: '777',
+    timestamp: '2013-11-29T23:05:40+00:00',
+    createdtime: '2013-11-28T23:07:40+00:00',
+    messagetext: 'A new message.'
+  }
+]
+```

--- a/_docs/tidepool-api/index.md
+++ b/_docs/tidepool-api/index.md
@@ -1,0 +1,116 @@
+---
+layout: defaults
+title: Tidepool API Guidebook
+published: true
+---
+
+# Tidepool API Guide (work in progress)
+
+This API is broken down into the following sections
+
+  * [User management](/tidepool-api/manage-user)
+  * [Uploading device data](/tidepool-api/uploading)
+  * [Accessing a user's data](/tidepool-api/downloading)
+  * [Editing notes](/tidepool-api/notes)
+  * [Sharing data](/tidepool-api/sharing)
+
+In addition, this page has logging in and making a data request (download) as a simple API walkthrough or tutorial.
+
+All requests URLs in this documentation are relative to `https://api.tidepool.io` (ex: `GET /auth/user` means `GET https://api.tidepool.io/auth/user`).
+
+## Simple Walkthrough
+
+### Login
+
+Login with a user's username and password using [HTTP Basic Auth](http://en.wikipedia.org/wiki/Basic_access_authentication):
+
+```
+POST /auth/login
+Authorization: Basic bmljb2xhc0B0aWRlcG9vbC5vcmc6dGVzdA==
+```
+Response:
+
+```
+200 OK
+x-tidepool-session-token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9[...]
+```
+
+```javascript
+{
+  "userid": "88144f5ea3",
+  "username": "mary@example.com",
+  "emails": ["mary@example.com"]
+}
+```
+
+Store the `x-tidepool-session-token` from the response headers. You will need it to make all subsequent requests for that user.
+
+If the login request fails because the username doesn't exist, or the password provided is wrong, you will get:
+
+```
+401 Unauthorized
+```
+
+```javascript
+"login failed"
+```
+
+### Refresh token
+
+A session token is **valid for 1 hour**, so you need to make sure to refresh it regularly by calling:
+
+```
+GET /auth/login
+x-tidepool-session-token: <current token>
+```
+
+Response:
+
+```
+200 OK
+x-tidepool-session-token: <current token>
+```
+
+```javascript
+{
+  "userid":"88144f5ea3"
+}
+```
+
+If you try to refresh with an invalid or expired token, you will get:
+
+```
+401 Unauthorized
+```
+
+```javascript
+"Session token required"
+```
+
+### Download some data
+
+TBD
+
+
+### Logout
+
+Expire the current session token with:
+
+```
+POST /auth/logout
+x-tidepool-session-token: <token>
+```
+
+Response:
+
+```
+200 OK
+```
+
+Note: Logging out with a token that has already expired will yield the same result.
+
+
+
+
+
+

--- a/_docs/tidepool-api/manage-user.md
+++ b/_docs/tidepool-api/manage-user.md
@@ -1,0 +1,208 @@
+---
+layout: defaults
+title: Tidepool API - Managing User
+published: true
+---
+
+# Tidepool API: Managing User
+
+For authentication, maintaining session token and logging out, see the introductory [API walkthrough](/tidepool-api/index) . 
+
+## User
+
+### Get user
+
+Defaults to current user
+
+There are two parts to the "user object", **account** and **profile** information.
+
+First, fetch the logged-in user's **account** information with:
+
+```
+GET /auth/user/:userid
+x-tidepool-session-token: <token>
+```
+
+Response:
+
+```
+200 OK
+```
+
+```javascript
+{
+  "userid": "88144f5ea3",
+  "username": "mary@example.com",
+  "emails": [
+    "mary@example.com"
+  ]
+}
+```
+
+Then fetch the **profile** information using the logged-in `userid` and session token:
+
+```
+GET /metadata/<userid>/profile
+x-tidepool-session-token: <token>
+
+```
+
+Response:
+
+```
+200 OK
+```
+
+```javascript
+{
+  "fullName": "Mary Smith",
+  "patient": {
+    "birthday": "1990-01-31",
+    "diagnosisDate": "1999-01-31",
+    "aboutMe": "I like oranges"
+  }
+}
+```
+
+
+## Confirmations
+
+There are three types of confirmations that can be generated:
+
+* Initial signup ("signup")
+* Forgot password ("forgot")
+* Invitations to another user to "join your care team" (a way of saying "give a user permission to access your data). ("invite")
+
+The three systems share the fact that they all deal with email notifications, but they differ in their details. The forgot password and signup systems are special because several of their operations need to be done without being authenticated (if you could log in, you wouldn't need to send a forgot password notification). The invitation system requires two users, and one of them may not yet have an account.
+
+The signup system (where we get a confirmation that new users actually have a valid email address) is the most generic, so we'll deal with it first:
+
+## Initial signup
+
+### Send a signup confirmation
+
+Send a signup confirmation email to a userid. 
+
+```
+POST /confirm/send/signup/:userid
+x-tidepool-session-token: <token>
+```
+
+This post is sent by the signup logic. In this state, the user account has been created but has a flag that forces the user to the confirmation-required page until the signup has been confirmed.
+
+(We need some rules about how often you can attempt a signup with a given email address, to keep this from being used to spam people either deliberately or accidentally. This call should also be throttled at the system level to prevent distributed attacks.)
+
+It sends an email that contains a random confirmation link. 
+
+### Resend confirmation 
+
+If a user didn't receive the confirmation email and logs in, they're directed to the confirmation-required page which can offer to resend the confirmation email. 
+
+```
+POST /confirm/resend/signup/:userid
+x-tidepool-session-token: <token>
+```
+
+
+### Accept/confirm a signup
+
+This would be PUT by the web page at the link in the signup email. No authentication is required.
+
+```
+PUT /confirm/accept/signup/:userid/:confirmationID
+```
+
+When this call is made, the flag that prevents login on an account is removed, and the user is directed to the login page. If the user has an active cookie for signup (created with a short lifetime) we can accept the presence of that cookie to allow the actual login to be skipped.
+
+### Dismiss a signup
+
+In the event that someone uses the wrong email address, the receiver could explicitly dismiss a signup attempt with this link (useful for metrics and to identify phishing attempts). This link would be some sort of parenthetical comment in the signup confirmation email, like "(I didn't try to sign up for Tidepool.)" No authentication required.
+
+```
+PUT /confirm/dismiss/signup/:userid
+```
+
+Making this request deletes the account record that was used to create the signup.
+
+### List signup confirmations
+
+This call is provided for completeness -- we don't expect to need it in the actual user flow.
+
+Fetch any existing confirmation requests. Will always return either 404 (not found) or a 200 with a single result in an array. 
+
+```
+GET /confirm/signup/:userid
+x-tidepool-session-token: <token>
+```
+
+
+### Delete an existing signup confirmation
+
+This call is provided for completeness -- we don't expect to need it in the actual user flow.
+
+Delete any existing confirmation request. If this is called, it deletes the request but does not delete the account.
+
+```
+DELETE /confirm/signup/:userid
+x-tidepool-session-token: <token>
+```
+
+
+## Lost password
+
+Lost passwords are special because they have to be created and accepted without the usual authentication.
+
+### Creating a lost password request:
+```
+POST /confirm/send/forgot/:useremail
+```
+
+If the request is correctly formed, always returns a 200, even if the email address was not found (this way it can't be used to validate email addresses).
+
+The call is throttled at the system level to limit distributed attacks.
+
+If the email address is found in the Tidepool system, this will:
+
+* Create a confirm record and a random key
+* Send an email with a link containing the key
+
+Visiting the URL in the email will fetch a page that offers the user the chance to accept or reject the lost password request. If accepted, the user must then create a new password that will replace the old one.
+
+
+### Accepting a lost password request
+
+```
+PUT /confirm/accept/forgot/
+
+body {
+  "key": "confirmkey"
+  "email": "address_on_the_account"
+  "password": "new_password"
+}
+```
+
+This call will be invoked by the lost password screen with the key that was included in the URL of the lost password screen. For additional safety, the user will be required to manually enter the email address on the account as part of the UI, and also to enter a new password which will replace the password on the account. 
+
+If this call is completed without error, the lost password request is marked as accepted. Otherwise, the lost password request remains active until it expires.
+
+### Dismiss a lost password request
+
+This is not necessary -- upon any successful login, the lost password request will be automatically deleted. (If the user successfully logs in after creating the lost password request, it is presumed that they didn't actually need to change it.)
+
+
+### Sign up
+
+[Create account, update profile]
+
+### Update user
+
+Defaults to current user
+
+[Update account, update profile]
+
+### Change password
+
+### Forgot password
+
+[Request password change, confirm new password]
+

--- a/_docs/tidepool-api/notes.md
+++ b/_docs/tidepool-api/notes.md
@@ -1,0 +1,19 @@
+---
+layout: defaults
+title: Tidepool API Guidebook - Downloading
+published: true
+---
+
+# Notes
+
+For downloading notes, see the API documentation on [accessing a user's data](/tidepool-api/downloading).  This section goes into more detail on adding and editing notes and messages, and managing threads. 
+
+For the rest of the API, see the [API walkthrough and overview](/tidepool-api/index) . 
+
+
+### Add note
+
+### Edit note
+
+### Get thread
+

--- a/_docs/tidepool-api/sharing.md
+++ b/_docs/tidepool-api/sharing.md
@@ -1,281 +1,15 @@
 ---
 layout: defaults
-title: Tidepool API Guidebook
+title: Tidepool API - Sharing
 published: true
 ---
 
-# Tidepool API Guide (work in progress)
+# Tidepool API: Sharing and Permissions
 
-All requests URLs in this documentation are relative to `https://api.tidepool.io` (ex: `GET /auth/user` means `GET https://api.tidepool.io/auth/user`).
+Tidepool user data can be shared flexibly with groups of other Tidepool users.  This document explains how to interact with the backend API to access those sharing functions. 
 
-## Auth
+For other API endpoints, see the introductory [API walkthrough](/tidepool-api/index) . 
 
-### Login
-
-Login with a user's username and password using [HTTP Basic Auth](http://en.wikipedia.org/wiki/Basic_access_authentication):
-
-```
-POST /auth/login
-Authorization: Basic bmljb2xhc0B0aWRlcG9vbC5vcmc6dGVzdA==
-```
-Response:
-
-```
-200 OK
-x-tidepool-session-token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9[...]
-```
-
-```javascript
-{
-  "userid": "88144f5ea3",
-  "username": "mary@example.com",
-  "emails": ["mary@example.com"]
-}
-```
-
-Store the `x-tidepool-session-token` from the response headers. You will need it to make all subsequent requests for that user.
-
-If the login request fails because the username doesn't exist, or the password provided is wrong, you will get:
-
-```
-401 Unauthorized
-```
-
-```javascript
-"login failed"
-```
-
-### Refresh token
-
-A session token is **valid for 1 hour**, so you need to make sure to refresh it regularly by calling:
-
-```
-GET /auth/login
-x-tidepool-session-token: <current token>
-```
-
-Response:
-
-```
-200 OK
-x-tidepool-session-token: <current token>
-```
-
-```javascript
-{
-  "userid":"88144f5ea3"
-}
-```
-
-If you try to refresh with an invalid or expired token, you will get:
-
-```
-401 Unauthorized
-```
-
-```javascript
-"Session token required"
-```
-
-### Logout
-
-Expire the current session token with:
-
-```
-POST /auth/logout
-x-tidepool-session-token: <token>
-```
-
-Response:
-
-```
-200 OK
-```
-
-Note: Logging out with a token that has already expired will yield the same result.
-
-## User
-
-### Get user
-
-Defaults to current user
-
-There are two parts to the "user object", **account** and **profile** information.
-
-First, fetch the logged-in user's **account** information with:
-
-```
-GET /auth/user/:userid
-x-tidepool-session-token: <token>
-```
-
-Response:
-
-```
-200 OK
-```
-
-```javascript
-{
-  "userid": "88144f5ea3",
-  "username": "mary@example.com",
-  "emails": [
-    "mary@example.com"
-  ]
-}
-```
-
-Then fetch the **profile** information using the logged-in `userid` and session token:
-
-```
-GET /metadata/<userid>/profile
-x-tidepool-session-token: <token>
-
-```
-
-Response:
-
-```
-200 OK
-```
-
-```javascript
-{
-  "fullName": "Mary Smith",
-  "patient": {
-    "birthday": "1990-01-31",
-    "diagnosisDate": "1999-01-31",
-    "aboutMe": "I like oranges"
-  }
-}
-```
-
-### Sign up
-
-[Create account, update profile]
-
-### Update user
-
-Defaults to current user
-
-[Update account, update profile]
-
-### Change password
-
-### Forgot password
-
-[Request password change, confirm new password]
-
-## Health data
-
-[Link to format documentation]
-
-### Get data
-
-[For Care Team, for date range]
-
-### Post data
-
-[One datum, an array of data]
-
-## Notes
-
-### Get notes
-
-Top level notes (i.e. no comments) within an optional date range
-
-```
-GET /message/notes/:groupid?starttime&endtime
-x-tidepool-session-token: <token>
-```
-
-Response:
-
-```
-200 OK
-```
-
-```javascript
-messages: [
- {
-    id: '123',
-    parentmessage : null,
-    userid: '777',
-    user: { "fullName": "Mary Smith" }, //users public profile
-    groupid: '777',
-    timestamp: '2013-11-28T23:07:40+00:00',
-    createdtime: '2013-11-28T23:07:40+00:00',
-    messagetext: 'In three words I can sum up everything I have learned about life: it goes on.'
-  },
-  {
-    id: '456',
-    parentmessage:null,
-    user: { "fullName": "Bob Smith" }, //users public profile
-    userid: '112',
-    groupid: '777',
-    timestamp: '2013-11-29T23:05:40+00:00',
-    createdtime: '2013-11-28T23:07:40+00:00',
-    messagetext: 'Second message.'
-  }
-]
-```
-
-### Get messages
-
-All messages within an optional date range
-
-```
-GET /message/all/:groupid?starttime&endtime
-x-tidepool-session-token: <token>
-```
-
-Response:
-
-```
-200 OK
-```
-
-```javascript
-messages: [
- {
-    id: '123',
-    parentmessage : null,
-    userid: '777',
-    user: { "fullName": "Mary Smith" }, //users public profile
-    groupid: '777',
-    timestamp: '2013-11-28T23:07:40+00:00',
-    createdtime: '2013-11-28T23:07:40+00:00',
-    messagetext: 'In three words I can sum up everything I have learned about life: it goes on.'
-  },
-  {
-    id: '456',
-    parentmessage:'123',
-    user: { "fullName": "Bob Smith" },
-    userid: '112',
-    groupid: '777',
-    timestamp: '2013-11-29T23:05:40+00:00',
-    createdtime: '2013-11-28T23:07:40+00:00',
-    messagetext: 'A comment.'
-  },
-  {
-    id: '789',
-    parentmessage: null,
-    user: { "fullName": "Bob Smith" },
-    userid: '112',
-    groupid: '777',
-    timestamp: '2013-11-29T23:05:40+00:00',
-    createdtime: '2013-11-28T23:07:40+00:00',
-    messagetext: 'A new message.'
-  }
-]
-```
-
-
-### Add note
-
-### Edit note
-
-### Get thread
 
 ## Groups
 
@@ -437,131 +171,6 @@ The "groupId" belongs to the user whose data is being accessed, and the userId b
   If a permission is not listed, the permission is not granted. 
 
 
-## Confirmations
-
-There are three types of confirmations that can be generated:
-
-* Initial signup ("signup")
-* Forgot password ("forgot")
-* Invitations to another user to "join your care team" (a way of saying "give a user permission to access your data). ("invite")
-
-The three systems share the fact that they all deal with email notifications, but they differ in their details. The forgot password and signup systems are special because several of their operations need to be done without being authenticated (if you could log in, you wouldn't need to send a forgot password notification). The invitation system requires two users, and one of them may not yet have an account.
-
-The signup system (where we get a confirmation that new users actually have a valid email address) is the most generic, so we'll deal with it first:
-
-## Initial signup
-
-### Send a signup confirmation
-
-Send a signup confirmation email to a userid. 
-
-```
-POST /confirm/send/signup/:userid
-x-tidepool-session-token: <token>
-```
-
-This post is sent by the signup logic. In this state, the user account has been created but has a flag that forces the user to the confirmation-required page until the signup has been confirmed.
-
-(We need some rules about how often you can attempt a signup with a given email address, to keep this from being used to spam people either deliberately or accidentally. This call should also be throttled at the system level to prevent distributed attacks.)
-
-It sends an email that contains a random confirmation link. 
-
-### Resend confirmation 
-
-If a user didn't receive the confirmation email and logs in, they're directed to the confirmation-required page which can offer to resend the confirmation email. 
-
-```
-POST /confirm/resend/signup/:userid
-x-tidepool-session-token: <token>
-```
-
-
-### Accept/confirm a signup
-
-This would be PUT by the web page at the link in the signup email. No authentication is required.
-
-```
-PUT /confirm/accept/signup/:userid/:confirmationID
-```
-
-When this call is made, the flag that prevents login on an account is removed, and the user is directed to the login page. If the user has an active cookie for signup (created with a short lifetime) we can accept the presence of that cookie to allow the actual login to be skipped.
-
-### Dismiss a signup
-
-In the event that someone uses the wrong email address, the receiver could explicitly dismiss a signup attempt with this link (useful for metrics and to identify phishing attempts). This link would be some sort of parenthetical comment in the signup confirmation email, like "(I didn't try to sign up for Tidepool.)" No authentication required.
-
-```
-PUT /confirm/dismiss/signup/:userid
-```
-
-Making this request deletes the account record that was used to create the signup.
-
-### List signup confirmations
-
-This call is provided for completeness -- we don't expect to need it in the actual user flow.
-
-Fetch any existing confirmation requests. Will always return either 404 (not found) or a 200 with a single result in an array. 
-
-```
-GET /confirm/signup/:userid
-x-tidepool-session-token: <token>
-```
-
-
-### Delete an existing signup confirmation
-
-This call is provided for completeness -- we don't expect to need it in the actual user flow.
-
-Delete any existing confirmation request. If this is called, it deletes the request but does not delete the account.
-
-```
-DELETE /confirm/signup/:userid
-x-tidepool-session-token: <token>
-```
-
-
-## Lost password
-
-Lost passwords are special because they have to be created and accepted without the usual authentication.
-
-### Creating a lost password request:
-```
-POST /confirm/send/forgot/:useremail
-```
-
-If the request is correctly formed, always returns a 200, even if the email address was not found (this way it can't be used to validate email addresses).
-
-The call is throttled at the system level to limit distributed attacks.
-
-If the email address is found in the Tidepool system, this will:
-
-* Create a confirm record and a random key
-* Send an email with a link containing the key
-
-Visiting the URL in the email will fetch a page that offers the user the chance to accept or reject the lost password request. If accepted, the user must then create a new password that will replace the old one.
-
-
-### Accepting a lost password request
-
-```
-PUT /confirm/accept/forgot/
-
-body {
-  "key": "confirmkey"
-  "email": "address_on_the_account"
-  "password": "new_password"
-}
-```
-
-This call will be invoked by the lost password screen with the key that was included in the URL of the lost password screen. For additional safety, the user will be required to manually enter the email address on the account as part of the UI, and also to enter a new password which will replace the password on the account. 
-
-If this call is completed without error, the lost password request is marked as accepted. Otherwise, the lost password request remains active until it expires.
-
-### Dismiss a lost password request
-
-This is not necessary -- upon any successful login, the lost password request will be automatically deleted. (If the user successfully logs in after creating the lost password request, it is presumed that they didn't actually need to change it.)
-
-
 ## Member Invitations
 
 ### Send member invitation
@@ -663,6 +272,8 @@ x-tidepool-session-token: <token>
 No body is required, but both :userid and :invitedby are required.
 
 
+
+
 ## Data accounts
 
 Create data account for myself (user `123`):
@@ -671,12 +282,12 @@ Update my profile (or account) object, from this:
 
 ```javascript
 var account = {
-	"userid": "123",
+  "userid": "123",
   "username": "msmith@example.com",
   "password": "secret"
 };
 var profile = {
-	"fullName": "Mary Smith"
+  "fullName": "Mary Smith"
 };
 ```
 
@@ -684,12 +295,12 @@ to this:
 
 ```javascript
 var account = {
-	"userid": "123",
+  "userid": "123",
   "username": "msmith@example.com",
   "password": "secret"
 };
 var profile = {
-	"fullName": "Mary Smith",
+  "fullName": "Mary Smith",
   "isDataAccount": true
 };
 ```
@@ -733,3 +344,4 @@ If all validation passes, the new account is created and the caller's account is
 
 
 It is not possible to remove last admin if account doesn't have login or recovery capabilities (i.e, if account doesn't have emails or password).
+

--- a/_docs/tidepool-api/sharing.md
+++ b/_docs/tidepool-api/sharing.md
@@ -8,18 +8,13 @@ published: true
 
 Tidepool user data can be shared flexibly with groups of other Tidepool users.  This document explains how to interact with the backend API to access those sharing functions. 
 
-For other API endpoints, see the introductory [API walkthrough](/tidepool-api/index) . 
+For other API endpoints, see the introductory [API walkthrough](/tidepool-api/index).  This API documentation is open-source -- please help keep it up-to-date.
 
 
-## Groups
+## Overview
 
-A better name for Groups would be "Permissions", but for historical reasons they're called groups. 
+A user's "groups" are the set of accounts for which the user has some permission.  A better name for Groups would be "Permissions", but for historical reasons they're called groups. 
 
-### Overview
-
-The "gatekeeper" project provides the mechanism by which Tidepool manages permissions between users.
-
-A user's "groups" are the set of accounts for which the user has some permission.
 
 The permissions currently available are:
 
@@ -73,11 +68,14 @@ If Carol asks "which groups am I in?", she might get back:
   Susie: view, upload, note
   Michael: view
 
-(Where Susie and Michael are other clients of hers.) The gatekeeper API is at the ```/access``` endpoint on Tidepool servers. Here's the list of things you can do with gatekeeper:
+(Where Susie and Michael are other clients of hers.) 
 
-### Which groups is a user in?
+Note to Tidepool developers: in the backend this is implemented in (gatekeeper)[https://github.com/tidepool-org/gatekeeper/blob/master/lib/server.js].  The gatekeeper API is at the ```/access``` endpoint on Tidepool servers.  
+
+## Which groups is a user in?
 
 This really means "whose data can a user access, and what permissions exist for each of them?"
+
 
 ```
 GET /access/groups/:userId
@@ -104,7 +102,11 @@ The response to this request would look something like this:
 }
 ```
 
-### Who can access a given user's data?
+### Error responses
+
+  * **401 Unauthorized**: The currently authenticated user does not have permissions to look at groups for the requested user.
+
+## Who can access a given user's data?
 
 This generates the list of userids that have access to the specified user's data, and which permissions they have.
 
@@ -126,7 +128,11 @@ The groupId here is the userId belonging to the session token, or someone for wh
 }
 ```
 
-### What permissions does userid have for groupid?
+### Error responses
+
+  * **401 Unauthorized**: The currently authenticated user does not have permissions to look at this group.
+
+## What permissions does userid have for groupid?
 
 This call checks a specific pair of users. The request is only valid if the session token making the request has admin permission on groupid, or if it is userid.
 
@@ -144,7 +150,13 @@ The "groupId" belongs to the user whose data is being accessed, and the userId b
 }
 ```
 
-### Set a user's permissions
+### Error responses
+
+  * **401 Unauthorized**: The currently authenticated user does not have permissions to look at this information.
+  * **404 Not Found**: The group does not grant any permissions to the user identified in the URL.
+  * **500 ServerError**: Another error occurred in the backend. 
+
+## Set a user's permissions
 
   This gives a user a specific set of permissions to access data.
 

--- a/_docs/tidepool-api/uploading.md
+++ b/_docs/tidepool-api/uploading.md
@@ -6,10 +6,56 @@ published: true
 
 # Uploading
 
-Introduction TBD
+For other parts of the API, including logging in and downloading data, navigate back or to the [API walkthrough](/tidepool-api/index). 
+
+## Model
+
+Applications can upload user health data to the Tidepool platform by logging in as the user whose health data is being accessed, or by a user with upload permissions (see [Sharing](/tidepool-api/sharing)).
 
 ## Post data
 
-[One datum, an array of data]
+To POST data to a given user based on group permissions, name the groupID.  One data point or an array of data points can be handled in the same POST request. 
+
+Note to developers: this request is currently handled by the [Jellyfish backend](https://github.com/tidepool-org/jellyfish/blob/master/lib/jellyfishService.js).
+
+```
+POST /data/:groupId
+x-tidepool-session-token: <token>
+Content-Type: application/json
+
+{ [
+  { "type": "basal",
+    ... rest of datum 
+  }
+]  }
+```
+
+One can also send data to the current logged-in user by substituting '/data/' for the URL in the above request. 
+
+**Success Response**
+
+```
+200 OK 
+
+<number of duplicates found in upload>
+```
+
+**Error Responses**
+
+**400 Client Error**: The request data has an unknown data type or other data format error
+
+**403 Forbidden**:  The logged-in user does not have permissions to upload data to the named location.  
+
+**500 Server Error**: A server-side error occurred.
+
+
+## Carelink Data
+
+```
+POST /v1/device/upload/cl?group
+x-tidepool-session-token: <token>
+```
 
 ## Overwriting
+
+As of April 13 2015, the uploading API does not allow clients to overwrite or delete data points.  Overwriting (e.g. to fix an error in adjusting timezones) is in the works. 

--- a/_docs/tidepool-api/uploading.md
+++ b/_docs/tidepool-api/uploading.md
@@ -1,0 +1,15 @@
+---
+layout: defaults
+title: Tidepool API - Uploading
+published: true
+---
+
+# Uploading
+
+Introduction TBD
+
+## Post data
+
+[One datum, an array of data]
+
+## Overwriting


### PR DESCRIPTION
The Tidepool API document was missing some information which I was able to get from reading code.  I also wanted to divide it up by topic/audience, because I think that is a reasonable way to make a long document a little more manageable and readable.

This does NOT link the document back into the rest of the microsite: I cannot find any links to this API document e.g. from the "Tidepool Developer Portal" page. 