### PR TITLE
Extra documentation for contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a Tidepool microsite for helping to guide and manage the open source nature of our work.
 
-This is a GitHub Pages site, and the deployed site can be found [here](http://developer.tidepool.io/).
+This is a GitHub Pages site, and the deployed site can be found [here](http://developer.tidepool.org/).
 
 If you want to run it locally, you should have a Ruby installation working and follow [GitHub's instructions for installing Jekyll](https://help.github.com/articles/using-jekyll-with-pages/#installing-jekyll).
 

--- a/_docs/raspberry-pi-getting-started.md
+++ b/_docs/raspberry-pi-getting-started.md
@@ -6,7 +6,7 @@ published: true
 
 **NB: This document is out-of-date and deprecated. It may be deleted soon. (If you'd like to save it by updating it, feel free to [open a pull request](https://github.com/tidepool-org/tidepool-org.github.io).)**
 
-Forays by [eurenda](https://github.com/eurenda) into installing Tidepool according to [instructions](http://developer.tidepool.io/starting-up-services/).
+Forays by [eurenda](https://github.com/eurenda) into installing Tidepool according to [instructions](http://developer.tidepool.org/starting-up-services/).
 
 Intended as a proof-of-concept.  No guarantees of speed, reliability, or usability (though everything seems to indicate that it is usable speed when rendered in Chrome):
 

--- a/_docs/tidepool-api/index.md
+++ b/_docs/tidepool-api/index.md
@@ -16,7 +16,7 @@ This API is broken down into the following sections
 
 In addition, this page has logging in and making a data request (download) as a simple API walkthrough or tutorial.
 
-All requests URLs in this documentation are relative to `https://api.tidepool.io` (ex: `GET /auth/user` means `GET https://api.tidepool.io/auth/user`).
+All requests URLs in this documentation are relative to `https://api.tidepool.org` (ex: `GET /auth/user` means `GET https://api.tidepool.org/auth/user`).
 
 ## Simple Walkthrough
 

--- a/index.md
+++ b/index.md
@@ -32,13 +32,13 @@ The intended audience for this microsite is software developers, but others may 
 * All of our technical documentation (a work in progress!):
   * [General docs](http://developer.tidepool.org/docs/) that don't belong to a specific app/repository, plus:
     * Tidepool for web (codenamed 'Blip') [docs](http://developer.tidepool.org/blip/) and [developer guide](http://developer.tidepool.org/blip/docs/StartHere.html)
-    * Tidepool Uploader Uploader (Chrome extension) [docs](http://developer.tidepool.org/chrome-uploader/) and [developer guide](http://developer.tidepool.org/chrome-uploader/docs/StartHere.html)
-    * The @tidepool/viz data visualization library [docs](http://developer.tidepool.io/viz/) and [developer guide](http://developer.tidepool.org/viz/docs/StartHere.html)
-  * [Tidepool data model documentation](http://developer.tidepool.io/data-model/)
+    * Tidepool Uploader (Electron application) [docs](http://developer.tidepool.org/chrome-uploader/) and [developer guide](http://developer.tidepool.org/chrome-uploader/docs/StartHere.html)
+    * The @tidepool/viz data visualization library [docs](http://developer.tidepool.org/viz/) and [developer guide](http://developer.tidepool.org/viz/docs/StartHere.html)
+  * [Tidepool data model documentation](http://developer.tidepool.org/data-model/)
 * Project Management references, including:
   * Our current [Work In Progress](https://trello.com/b/sLQWlC52/work-in-progress) Trello board
   * The [Active Product Design](https://trello.com/b/EdZQUlp6/active-product-design) board on Trello, which is the immediate source for tasks on the [Work In Progress](https://trello.com/b/sLQWlC52/work-in-progress) board
-  * "Maybe someday" backlogs for [Blip](https://trello.com/b/iKydvoiJ/backlog-blip), [Uploader](https://trello.com/b/oHy9VXYY/backlog-uploader), [Blip Notes](https://trello.com/b/jjciNmRJ/backlog-blip-notes), [Backend](https://trello.com/b/RUDDN3yq/backlog-backend)
+  * "Maybe someday" backlogs for [Blip](https://trello.com/b/iKydvoiJ/backlog-blip), [Tidepool Uploader](https://trello.com/b/oHy9VXYY/backlog-uploader), [Blip Notes](https://trello.com/b/jjciNmRJ/backlog-blip-notes), [Backend](https://trello.com/b/RUDDN3yq/backlog-backend)
 * Our [Terms of Use](terms-of-use) and [Privacy Policy](privacy-policy), maintained here on GitHub.
 
 ## A Note about Contributing to Tidepool's Source Code
@@ -47,7 +47,6 @@ Since our founding in 2013, Tidepool has had dozens of volunteer contributors to
 
 To cut to the chase: Although we are an open source project, we are not currently set up in a way that makes it easy to contribute code back to Tidepool and have it merged in with our production software. There are lots of reasons for this:
 
-* Our platform is pretty complicated to get set up and running locally, and we don't have a good Docker or Vagrant container setup.
 * We tend to give ourselves aggressive sprint goals, which does not leave enough slack to support outside contributors.
 * We don't have anyone whose job is to ensure the success of the open source community (though we'd like to add this… please [let us know](mailto:jobs@tidepool.org) if you are interested!)
 
@@ -60,16 +59,17 @@ If you think you think you'd like to contribute designs, code, or or anything el
 
 Depending on what kind of work you are trying to do, you may wish to engage with our source code in different ways:
 
-* **Tidepool Uploader**: If you'd like to help add device support to the Tidepool Uploader, check out the [chrome-uploader](https://github.com/tidepool-org/chrome-uploader) repository. (You can also install the production [Tidepool Uploader from the Chrome Web Store](https://chrome.google.com/webstore/detail/tidepool-uploader/cabklgajffclbljkhmjphejemhpbghfb).)
-* **Tidepool for web**: You may wish to build Tidepool for web (codename 'Blip'), locally but still run against our hosted back-end services. If so, check out the README in the [blip](https://github.com/tidepool-org/blip) repository. (Of course you can also just run the production Tidepool for web at [app.tidepool.org](https://app.tidepool.org).
+* **Tidepool Uploader**: If you'd like to help add device support to the Tidepool Uploader, check out the [Tidepool Uploader](https://github.com/tidepool-org/chrome-uploader) repository. (You can also install the production [Tidepool Uploader from our GitHub Releases](https://github.com/tidepool-org/chrome-uploader/releases)).
+* **Tidepool for web**: You may wish to build Tidepool for web (codename 'Blip'), locally but still run against our hosted back-end services. If so, check out the README in the [blip](https://github.com/tidepool-org/blip) repository. (Of course you can also just run the production Tidepool for web at [app.tidepool.org](https://app.tidepool.org)).
+* **Tidepool Platform**: If you want to run the entire platform locally, check out [the instructions in our tools repository](https://github.com/tidepool-org/tools/#docker-development-environment). This will get you running our environment locally using Docker.
 * **Your Applications**: You may wish create your own application that accesses our hosted back-end services (the Tidepool Platform). If it's a web app, you may wish to look at Tidepool for web. If it's a mobile app, check out Tidepool Mobile in the [Nutshell](https://github.com/tidepool-org/nutshell-ios) or [Urchin for Android](https://github.com/tidepool-org/urchin-android) or [Urchin for iOS](https://github.com/tidepool-org/urchin). Note that Blip Notes and Nutshell are being retired. Both will be replaced by Tidepool Mobile, currently under development in the Nutshell repo.
   * Please don't develop your app against our production environment without talking to us. Instead, please use our integration environment, found at int-app.tidepool.org and int-api.tidepool.org.
-  * Read our [data model documentation](http://developer.tidepool.io/data-model/) to understand what medical data we ingest and how it’s organized.
+  * Read our [data model documentation](http://developer.tidepool.org/data-model/) to understand what medical data we ingest and how it’s organized.
   * [These comments](https://github.com/tidepool-org/tide-whisperer/blob/master/tide-whisperer.go#L193) show some documentation for our data APIs.
 
 ## Communication
 
-We are currently using Slack for communication with the open source community. Join us at [tidepoolorg.slack.com](https://tidepoolorg.slack.com). We are very grateful to community members who have been so generous with their time supporting other members.
+We are currently using Slack for communication with the open source community. Join us at [tidepoolorg.slack.com](https://tidepoolorg.slack.com/shared_invite/enQtMjcwMjA0NDM4NzI1LTNlODQ4ZWVjYTYzZGVjMDI5NGUwZjhmYzcyYzEzYTgxOGE2NzdlZjU3Zjk4MTJkNDU0NjA1ZjBhNDUzMmU5NzE). We are very grateful to community members who have been so generous with their time supporting other members.
 
 Feel free to drop a note to [info@tidepool.org](mailto:info@tidepool.org), and it will find the right recipient quickly.
 


### PR DESCRIPTION
* Add info about Docker
* Change all references to tidepool.io to tidepool.org
* Add link to Slack self sign-up